### PR TITLE
Bug 177 Fix

### DIFF
--- a/wins/admin/sample.ini
+++ b/wins/admin/sample.ini
@@ -109,7 +109,7 @@ DOMAIN = wwivbbs.com
 ;
 ; Your news host where your authorized to retrieve newsgroup articles. Multiple
 ; servers can be defined as indicated below.
-NEWSHOST = <NNTP.NEWSPROVIDER.COM>
+;NEWSHOST = <NNTP.NEWSPROVIDER.COM>
 ;NEWSHOST0 = <NNTP.NEWSPROVIDER0.COM>
 ;NEWSHOST1 = <NNTP.NEWSPROVIDER1.COM>
 ;
@@ -124,37 +124,37 @@ NEWSHOST = <NNTP.NEWSPROVIDER.COM>
 ;NEWSPASS0 = <NEWSPASSWORD0>
 ;
 ; Account to send inbound mail which isn't addressed to a specific user.
-POSTMASTER = 1
+;POSTMASTER = 1
 ; Use WWIV real name (USER.LST) instead of the alias on outbound mail.
-REALNAME = Y
+;REALNAME = Y
 ;
 ; Use a fake name on newsgroup posts to prevent getting unsolicited mail.
-SPAMCONTROL = Y
+;SPAMCONTROL = Y
 ;
 ; User-defined fake name when SPAMCONTROL=Y (must have an '@' and a '.').
- SPAMADDRESS = YourFake Email@some.com.remove.com
+;SPAMADDRESS = YourFake Email@some.com.remove.com
 ;
 ; User-defined fake name when SPAMCONTROL=Y (must have an '@' and a '.').
-REPLYTO = Your email@your.com.remove.com (remove SPAM)
+;REPLYTO = Your email@your.com.remove.com (remove SPAM)
 ;
 ; Signature file to append to newsgroup posts and Internet mail (ASCII only!)
-SIGNATURE = C:\WWIV\GFILES\INTERNET.TAG
+;SIGNATURE = C:\WWIV\GFILES\INTERNET.TAG
 ;
 ; Maximum number of cross-posts before discarding a newsgroup article as spam.
-XPOSTS = 5
+;XPOSTS = 5
 ;
 ; Bypass crosspost check on binary newsgroups?  If 'Y' does *not* check the
 ; number of crossposts.
-BINXPOST = Y
+;BINXPOST = Y
 ;
 ; Update the NEWSRC (newsgroups listing) from your provider on each connect?
 ; If 'Y', the NEWGROUPS command is issued each day and a complete listing is
 ; retrieved the first of each month.
-NEWSRC_UPD = Y
+;NEWSRC_UPD = Y
 ;
 ; Operate in "stealth" mode with streamlined display, no display of subjects,
 ; etc.  Useful to prevent prying eyes from seeing what's being retrieved.
-QUIET = N
+;QUIET = N
 ;
 ; Mailing List Section - used to define internet mailing lists that are to
 ; be retrieved into a message base rather than EMAIL.
@@ -164,19 +164,9 @@ QUIET = N
 ; Issue mailing lists in "digest" mode, where posts are collected during the
 ; day and sent as a single, large message the subsequent day.  This will be
 ; further enhanced in the future.
-DIGEST = Y
+;DIGEST = Y
 ;
 ; Add the subscribed mailing lists in the following format:
 ; email_name  *subtype  (NOTE: Asterisk is required on subtype!)
 ; my_listserv@domain.com *1000
 [END]
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Commented out the Lines after NEWS and MAILLIST. There's no reason for
these settings to be enabled by default especially for new SysOps.

Fixes #177
