### PR TITLE
Fix https://github.com/wwivbbs/wwiv/issues/191

### DIFF
--- a/builds/jenkins/wwiv/build.cmd
+++ b/builds/jenkins/wwiv/build.cmd
@@ -24,53 +24,80 @@
 
 set ZIP_EXE="C:\Program Files\7-Zip\7z.exe"
 set RELEASE_ZIP=%WORKSPACE%\wwiv-build-win-%BUILD_NUMBER%.zip
-echo Workspace:    %WORKSPACE%         
-echo Build Number: %BUILD_NUMBER%
-echo Archive:      %RELEASE_ZIP%
+echo TextTransform: %TEXT_TRANSFORM%
+echo Workspace:     %WORKSPACE%         
+echo Build Number:  %BUILD_NUMBER%
+echo Archive:       %RELEASE_ZIP%
 
 @rem Build BBS, init, telnetserver
+echo:
+echo U* pdating the Build Number in version.cpp
 cd %WORKSPACE%\core
 %TEXT_TRANSFORM% -a !!version!%BUILD_NUMBER% version.template
-msbuild bbs_lib.vcxproj /t:Build /p:Configuration=Release
-msbuild bbs.vcxproj /t:Build /p:Configuration=Release
 
+echo:
+echo * Building CORE
+cd %WORKSPACE%\core
+msbuild core.vcxproj /t:Build /p:Configuration=Release || exit /b
+
+echo:
+echo * Building BBS
+cd %WORKSPACE%\bbs
+msbuild bbs_lib.vcxproj /t:Build /p:Configuration=Release || exit /b
+msbuild bbs.vcxproj /t:Build /p:Configuration=Release || exit /b
+
+echo:
+echo * Building WWIV5TelnetServer
 cd %WORKSPACE%\WWIV5TelnetServer\WWIV5TelnetServer
-msbuild WWIV5TelnetServer.csproj /t:Build /p:Configuration=Release
+msbuild WWIV5TelnetServer.csproj /t:Build /p:Configuration=Release || exit /b
 
+echo:
+echo * Building INITLIB
 cd %WORKSPACE%\initlib
-msbuild initlib.vcxproj /t:Build /p:Configuration=Release
+msbuild initlib.vcxproj /t:Build /p:Configuration=Release || exit /b
 
+echo:
+echo * Building INIT
 cd %WORKSPACE%\init
-msbuild init.vcxproj /t:Build /p:Configuration=Release
+msbuild init.vcxproj /t:Build /p:Configuration=Release || exit /b
 
+echo:
+echo * Building NETWORKB
 cd %WORKSPACE%\networkb
-msbuild networkb.vcxproj /t:Build /p:Configuration=Release
+msbuild networkb.vcxproj /t:Build /p:Configuration=Release || exit /b
 
+echo:
+echo * Building NETWORK
 cd %WORKSPACE%\network
-msbuild network.vcxproj /t:Build /p:Configuration=Release
+msbuild network.vcxproj /t:Build /p:Configuration=Release || exit /b
 
+echo:
+echo * Building FIX
 cd %WORKSPACE%\fix
 msbuild fix.vcxproj /t:Build /p:Configuration=Release /property:EnableEnhancedInstructionSet=NoExtensions
 
 @rem build WINS
+echo:
+echo * Building WINS
 cd %WORKSPACE%\wins
 
-msbuild exp\exp.vcxproj /t:Build /p:Configuration=Release
-msbuild networkp\networkp.vcxproj /t:Build /p:Configuration=Release
-msbuild news\news.vcxproj /t:Build /p:Configuration=Release
-msbuild ntime\ntime.vcxproj /t:Build /p:Configuration=Release
-msbuild pop\pop.vcxproj /t:Build /p:Configuration=Release
-msbuild pppurge\pppurge.vcxproj /t:Build /p:Configuration=Release
-msbuild ppputil\ppputil.vcxproj /t:Build /p:Configuration=Release
-msbuild qotd\qotd.vcxproj /t:Build /p:Configuration=Release
-msbuild uu\uu.vcxproj /t:Build /p:Configuration=Release
+msbuild exp\exp.vcxproj /t:Build /p:Configuration=Release || exit /b
+msbuild networkp\networkp.vcxproj /t:Build /p:Configuration=Release || exit /b
+msbuild news\news.vcxproj /t:Build /p:Configuration=Release || exit /b
+msbuild pop\pop.vcxproj /t:Build /p:Configuration=Release || exit /b
+msbuild pppurge\pppurge.vcxproj /t:Build /p:Configuration=Release || exit /b
+msbuild ppputil\ppputil.vcxproj /t:Build /p:Configuration=Release || exit /b
+msbuild qotd\qotd.vcxproj /t:Build /p:Configuration=Release || exit /b
+msbuild uu\uu.vcxproj /t:Build /p:Configuration=Release || exit /b
 
 
 @rem build DEPS
+echo:
+echo * Building INFOZIP (zip/unzip)
 cd %WORKSPACE%\deps\infozip
 
-msbuild unzip60\win32\vc8\unzip.vcxproj /t:Build /p:Configuration=Release
-msbuild zip30\win32\vc6\zip.vcxproj /t:Build /p:Configuration=Release
+msbuild unzip60\win32\vc8\unzip.vcxproj /t:Build /p:Configuration=Release || exit /b
+msbuild zip30\win32\vc6\zip.vcxproj /t:Build /p:Configuration=Release || exit /b
 
 cd %WORKSPACE%\
 if not exist %WORKSPACE%\release (
@@ -80,16 +107,20 @@ if not exist %WORKSPACE%\release (
 del /q %WORKSPACE%\release
 del wwiv-build-*.zip
 
-echo Create Menus (EN)
+echo:
+echo * Creating Menus (EN)
 cd %WORKSPACE%\bbs\admin\menus\en
 %ZIP_EXE% a -tzip -r %WORKSPACE%\release\en-menus.zip *
 
+echo:
+echo * Creating Regions
 cd %WORKSPACE%\bbs\admin
 %ZIP_EXE% a -tzip -r %WORKSPACE%\release\zip-city.zip zip-city\*
 %ZIP_EXE% a -tzip -r %WORKSPACE%\release\regions.zip regions\*
 
 cd %WORKSPACE%\
-echo Copying BBS files to staging directory.
+echo:
+echo * Copying BBS files to staging directory.
 copy /v/y %WORKSPACE%\bbs\Release\bbs.exe %WORKSPACE%\release\bbs.exe
 copy /v/y %WORKSPACE%\WWIV5TelnetServer\WWIV5TelnetServer\bin\release\WWIV5TelnetServer.exe %WORKSPACE%\release\WWIV5TelnetServer.exe
 copy /v/y %WORKSPACE%\init\Release\init.exe %WORKSPACE%\release\init.exe
@@ -98,19 +129,20 @@ copy /v/y %WORKSPACE%\networkb\Release\networkb.exe %WORKSPACE%\release\networkb
 copy /v/y %WORKSPACE%\fix\Release\fix.exe %WORKSPACE%\release\fix.exe
 copy /v/y %WORKSPACE%\bbs\admin\* %WORKSPACE%\release\
 
-echo Copying WINS files to staging area
+echo:
+echo * Copying WINS files to staging area
 set WINS=%WORKSPACE%\wins
 copy /v/y %WINS%\exp\Release\exp.exe %WORKSPACE%\release\exp.exe
 copy /v/y %WINS%\networkp\Release\networkp.exe %WORKSPACE%\release\networkp.exe
 copy /v/y %WINS%\news\Release\news.exe %WORKSPACE%\release\news.exe
-copy /v/y %WINS%\ntime\Release\ntime.exe %WORKSPACE%\release\ntime.exe
 copy /v/y %WINS%\pop\Release\pop.exe %WORKSPACE%\release\pop.exe
 copy /v/y %WINS%\pppurge\Release\pppurge.exe %WORKSPACE%\release\pppurge.exe
 copy /v/y %WINS%\ppputil\Release\ppputil.exe %WORKSPACE%\release\ppputil.exe
 copy /v/y %WINS%\qotd\Release\qotd.exe %WORKSPACE%\release\qotd.exe
 copy /v/y %WINS%\uu\Release\uu.exe %WORKSPACE%\release\uu.exe
 
-echo Copying INFOZIP files to staging area
+echo:
+echo * Copying INFOZIP files to staging area
 set INFOZIP=%WORKSPACE%\deps\infozip
 dir %INFOZIP%\unzip60\win32\vc8\unzip__Win32_Release\unzip.exe
 dir %INFOZIP%\zip30\win32\vc6\zip___Win32_Release\zip.exe
@@ -118,14 +150,20 @@ copy /v/y %INFOZIP%\unzip60\win32\vc8\unzip__Win32_Release\unzip.exe %WORKSPACE%
 copy /v/y %INFOZIP%\zip30\win32\vc6\zip___Win32_Release\zip.exe %WORKSPACE%\release\zip.exe
 
 
-echo Creating build.nfo file
+echo:
+echo * Creating build.nfo file
 echo Build URL %BUILD_URL% > release\build.nfo
 echo Subversion Build: %BUILD_NUMBER% >> release\build.nfo
 
-echo Creating release archive: %RELEASE_ZIP%
+echo:
+echo * Creating release archive: %RELEASE_ZIP%
 cd %WORKSPACE%\release
 %ZIP_EXE% a -tzip -y %RELEASE_ZIP%
 
-echo Archive File: %RELEASE_ZIP%
-echo Archive contents:
+echo:
+echo:
+echo: **** SUCCESS ****
+echo:
+echo ** Archive File: %RELEASE_ZIP%
+echo ** Archive contents:
 %ZIP_EXE% l %RELEASE_ZIP%

--- a/builds/jenkins/wwiv/rushfan-build.cmd
+++ b/builds/jenkins/wwiv/rushfan-build.cmd
@@ -2,6 +2,8 @@ SET TEXT_TRANSFORM="C:\Program Files\Common Files\microsoft shared\TextTemplatin
 SET WORKSPACE=W:\wwiv
 SET BUILD_NUMBER=2112
 pushd %WORKSPACE%
-call %WORKSPACE%\builds\jenkins\wwiv\build.cmd
+copy %WORKSPACE%\core\version.cpp %WORKSPACE%\core\version.cpp.saved
+call %WORKSPACE%\builds\jenkins\wwiv\build.cmd || echo "Build FAILED!"
+copy %WORKSPACE%\core\version.cpp.saved %WORKSPACE%\core\version.cpp
 popd
 


### PR DESCRIPTION
Builds are broken and go unnoticed on win32.
Now after each msbuild command add "|| exit /b", this is
similar to what "set -e" does in bash automagically
and will fail the build if any command fails, right now
teh build succeeds and old artifacts (if any) are continued
to be propagated into the build zip file.

Also fixed the build script to work with error checking
(removed ntime reference) and improved the display a bit
by adding some empty lines before each heading and adding a *
to make the display more readable.
