### PR TITLE
Fix crash when there is no tagline, trying to check for

### DIFF
--- a/bbs/inmsg.cpp
+++ b/bbs/inmsg.cpp
@@ -603,6 +603,10 @@ void UpdateMessageBufferTagLine(char *pszMessageBuffer, long *plBufferLength, co
   }
 
   const string filename = FindTagFileName();
+  if (filename.empty()) {
+    // FindTagFileName returns an empty string if no tagname exists, so
+    // just exit here since there is no tag.
+  }
   TextFile file(filename, "rb");
   if (file.IsOpen()) {
     int j = 0;

--- a/core/file.cpp
+++ b/core/file.cpp
@@ -271,6 +271,12 @@ bool File::Remove(const string& directoryName, const string& fileName) {
 }
 
 bool File::Exists(const string& original_pathname) {
+  if (original_pathname.empty()) {
+    // An empty filename can not exist.
+    // The question is should we assert here?
+    return false;
+  }
+
   string fn(original_pathname);
   if (fn.back() == pathSeparatorChar) {
     // If the pathname ends in / or \, then remove the last character.


### PR DESCRIPTION
existance of a file with an empty filename was crashing
the system.  So don't pass an empty filename on when there
is no tag file, also don't crash if the filename is empty
on File::Exists, just return false. I'm not sure if that
is right, but it's no more wrong than crashing I think.
