### PR TITLE
Altered filename case of en-menus.zip to fix Linux init

### DIFF
--- a/init/newinit.cpp
+++ b/init/newinit.cpp
@@ -310,7 +310,7 @@ static void init_files(CursesWindow* window, const string& bbsdir) {
   window->Puts("Decompressing archives.  Please wait");
   window->SetColor(SchemeId::NORMAL);
   if (File::Exists("en-menus.zip")) {
-    system("unzip -qq -o EN-menus.zip -dgfiles ");
+    system("unzip -qq -o en-menus.zip -dgfiles ");
     File::Rename("en-menus.zip", 
                  StringPrintf("dloads%csysop%cen-menus.zip",
                               File::pathSeparatorChar,


### PR DESCRIPTION
Linux is case-sensitive. Sometimes it gets in the way.
