### PR TITLE
Cleanups

### DIFF
--- a/bbs/automsg.cpp
+++ b/bbs/automsg.cpp
@@ -41,8 +41,8 @@ void write_automessage();
  */
 void read_automessage() {
   bout.nl();
-  unique_ptr<WStatus> status(application()->GetStatusManager()->GetStatus());
-  bool bAutoMessageAnonymous = status->IsAutoMessageAnonymous();
+  unique_ptr<WStatus> current_status(application()->GetStatusManager()->GetStatus());
+  bool bAutoMessageAnonymous = current_status->IsAutoMessageAnonymous();
 
   TextFile autoMessageFile(syscfg.gfilesdir, AUTO_MSG, "rt");
   string line;

--- a/bbs/batch.cpp
+++ b/bbs/batch.cpp
@@ -320,8 +320,8 @@ void zmbatchdl(bool bHangupAfterDl) {
       if (nRecordNumber <= 0) {
         delbatch(cur);
       } else {
-        const string message = StringPrintf("Files left - %d, Time left - %s\r\n", session()->numbatchdl, ctim(batchtime));
-        session()->localIO()->LocalPuts(message);
+        session()->localIO()->LocalPuts(
+            StringPrintf("Files left - %d, Time left - %s\r\n", session()->numbatchdl, ctim(batchtime)));
         File file(g_szDownloadFileName);
         file.Open(File::modeBinary | File::modeCreateFile | File::modeReadWrite);
         FileAreaSetRecord(file, nRecordNumber);

--- a/bbs/batch.cpp
+++ b/bbs/batch.cpp
@@ -844,7 +844,7 @@ void bihangup(int up) {
   do {
     while (!bkbhit() && !hangup) {
       long dd = timer1();
-      if (labs(dd - timelastchar1) > 65536L) {
+      if (abs(dd - timelastchar1) > 65536L) {
         nextbeep -= 1572480L;
         timelastchar1 -= 1572480L;
       }
@@ -859,7 +859,7 @@ void bihangup(int up) {
           color = 6;
         }
       }
-      if (labs(dd - timelastchar1) > 182L) {
+      if (abs(dd - timelastchar1) > 182L) {
         bout.nl();
         bout << "Thank you for calling.";
         bout.nl();

--- a/bbs/bbs.cpp
+++ b/bbs/bbs.cpp
@@ -516,7 +516,7 @@ int WApplication::doWFCEvents() {
           session()->SetFileAreaCacheNumber(session()->GetFileAreaCacheNumber() + 1);
         } else {
           static int mult_time = 0;
-          if (this->IsCleanNetNeeded() || labs(timer1() - mult_time) > 1000L) {
+          if (this->IsCleanNetNeeded() || abs(timer1() - mult_time) > 1000L) {
             cleanup_net();
             mult_time = timer1();
             giveup_timeslice();

--- a/bbs/bbs.cpp
+++ b/bbs/bbs.cpp
@@ -17,6 +17,8 @@
 /*                                                                        */
 /**************************************************************************/
 #ifdef _WIN32
+// include this here so it won't get includes by local_io_win32.h
+#include "bbs/wwiv_windows.h"
 #include <direct.h>
 #endif  // WIN32
 
@@ -41,7 +43,6 @@
 #include "bbs/fcns.h"
 #include "bbs/input.h"
 #include "bbs/instmsg.h"
-#include "bbs/keycodes.h"
 #include "bbs/local_io.h"
 #include "bbs/local_io_curses.h"
 #include "bbs/null_local_io.h"

--- a/bbs/bbs.h
+++ b/bbs/bbs.h
@@ -95,12 +95,6 @@ class WApplication : public WLogger, Runnable {
   const std::string& GetAttachmentDirectory() { return m_attachmentDirectory; }
 
   /*!
-   * @var networkNumEnvVar Environment variable style
-   *      listing of WWIV net number, (only used for the xenviron)
-   */
-  std::string networkNumEnvVar;
-
-  /*!
    * @function GetHomeDir Returns the current home directory
    */
   const std::string GetHomeDir();
@@ -114,7 +108,7 @@ class WApplication : public WLogger, Runnable {
   /*! @function QuitBBS - Shuts down the bbs at the "QUIT" error level */
   void QuitBBS();
 
-  int  GetInstanceNumber() const { return instance_number; }
+  int  GetInstanceNumber() const { return instance_number_; }
   const std::string& GetNetworkExtension() const { return network_extension; }
 
   void UpdateTopScreen();
@@ -192,7 +186,7 @@ private:
   char            m_szCurrentDirectory[ MAX_PATH ];
   int             m_nOkLevel;
   int             m_nErrorLevel;
-  int             instance_number;
+  int             instance_number_;
   std::string     network_extension;
   double          last_time;
   bool            m_bUserAlreadyOn;

--- a/bbs/bbs.vcxproj
+++ b/bbs/bbs.vcxproj
@@ -53,7 +53,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDir)</AdditionalIncludeDirectories>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
@@ -73,7 +73,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDir)</AdditionalIncludeDirectories>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>

--- a/bbs/bbs_lib.vcxproj
+++ b/bbs/bbs_lib.vcxproj
@@ -53,7 +53,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;_USE_32BIT_TIME_T;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions);_CRT_NONSTDC_NO_DEPRECATE</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions);_CRT_NONSTDC_NO_DEPRECATE</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDir)</AdditionalIncludeDirectories>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
@@ -73,7 +73,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions);_CRT_NONSTDC_NO_DEPRECATE</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions);_CRT_NONSTDC_NO_DEPRECATE</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDir)</AdditionalIncludeDirectories>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>

--- a/bbs/bbsovl3.cpp
+++ b/bbs/bbsovl3.cpp
@@ -124,10 +124,10 @@ int get_kb_event(int nNumLockMode) {
         if (key == RETURN || key == CL) {
           return EXECUTE;
         } else if (key == ESC) {
-          time_t time1 = time(nullptr);
-          time_t time2 = time(nullptr);
+          time_t esc_time1 = time(nullptr);
+          time_t esc_time2 = time(nullptr);
           do {
-            time2 = time(nullptr);
+            esc_time2 = time(nullptr);
             if (bkbhitraw()) {
               key = pd_getkey();
               if (key == OB || key == O) {
@@ -162,9 +162,9 @@ int get_kb_event(int nNumLockMode) {
                 return GET_OUT;
               }
             }
-          } while (difftime(time2, time1) < 1 && !hangup);
+          } while (difftime(esc_time2, esc_time1) < 1 && !hangup);
 
-          if (difftime(time2, time1) >= 1) {     // if no keys followed ESC
+          if (difftime(esc_time2, esc_time1) >= 1) {     // if no keys followed ESC
             return GET_OUT;
           }
         } else {

--- a/bbs/chat.cpp
+++ b/bbs/chat.cpp
@@ -205,7 +205,7 @@ int f_action(int nStartPos, int nEndPos, char *pszAWord) {
 
 
 int main_loop(char *pszMessage, char *pszFromMessage, char *pszColorString, char *pszMessageSent, bool &bActionMode,
-              int loc, int g_nNumActions) {
+              int loc, int num_actions) {
   char szText[300];
   WUser u;
 
@@ -232,7 +232,7 @@ int main_loop(char *pszMessage, char *pszFromMessage, char *pszColorString, char
     bout.nl();
   } else if (IsEqualsIgnoreCase(pszMessage, "list")) {
     bout.nl();
-    for (int i2 = 0; i2 <= g_nNumActions; i2++) {
+    for (int i2 = 0; i2 <= num_actions; i2++) {
       bout.bprintf("%-16.16s", actions[i2]->aword);
     }
     bout.nl();

--- a/bbs/chnedit.cpp
+++ b/bbs/chnedit.cpp
@@ -86,7 +86,6 @@ void ShowChainCommandLineHelp() {
 void modify_chain(int nCurrentChainNumber) {
   chainregrec r;
   char s[255], s1[255], ch, ch2;
-  int i;
   memset(&r, 0, sizeof(chainregrec));
 
   chainfilerec c = chains[ nCurrentChainNumber ];
@@ -196,15 +195,15 @@ void modify_chain(int nCurrentChainNumber) {
         strcpy(c.filename, s);
       }
       break;
-    case 'C':
+    case 'C': {
       bout.nl();
       bout << "|#7New SL? ";
       input(s, 3, true);
-      i = atoi(s);
-      if ((i >= 0) && (i < 256) && (s[0])) {
-        c.sl = static_cast< unsigned char >(i);
+      int sl = atoi(s);
+      if ((sl >= 0) && (sl < 256) && (s[0])) {
+        c.sl = static_cast<unsigned char>(sl);
       }
-      break;
+    } break;
     case 'D':
       bout.nl();
       bout << "|#7New AR (<SPC>=None) ? ";
@@ -264,7 +263,7 @@ void modify_chain(int nCurrentChainNumber) {
       if (!application()->HasConfigFlag(OP_FLAGS_CHAIN_REG)) {
         break;
       }
-      for (i = 0; i < 5; i++) {
+      for (int i = 0; i < 5; i++) {
         bout.nl();
         bout << "|#9(Q=Quit, 0=None) User name/number: : ";
         input(s1, 30, true);
@@ -278,8 +277,8 @@ void modify_chain(int nCurrentChainNumber) {
               application()->users()->ReadUser(&regUser, nUserNumber);
               r.regby[i] = static_cast< short >(nUserNumber);
               bout.nl();
-              bout << "|#1Registered by       |#2" << nUserNumber << " " << ((r.regby[i]) ? regUser.GetName() :
-                                 "AVAILABLE");
+              bout << "|#1Registered by       |#2" << nUserNumber << " " 
+                   << ((r.regby[i]) ? regUser.GetName() : "AVAILABLE");
             }
           }
         } else {
@@ -330,7 +329,6 @@ void modify_chain(int nCurrentChainNumber) {
 
 void insert_chain(int nCurrentChainNumber) {
   chainfilerec c;
-  chainregrec r;
 
   for (int i = session()->GetNumberOfChains() - 1; i >= nCurrentChainNumber; i--) {
     chains[i + 1] = chains[i];
@@ -347,6 +345,7 @@ void insert_chain(int nCurrentChainNumber) {
   c.ansir |= ansir_no_DOS;
   session()->SetNumberOfChains(session()->GetNumberOfChains() + 1);
   if (application()->HasConfigFlag(OP_FLAGS_CHAIN_REG)) {
+    chainregrec r;
     memset(&r, 0, sizeof(r));
     r.maxage = 255;
     chains_reg[ nCurrentChainNumber ] = r;

--- a/bbs/com.cpp
+++ b/bbs/com.cpp
@@ -149,7 +149,7 @@ char getkey() {
       if (dd < timelastchar1 && ((dd + 1000) > timelastchar1)) {
         timelastchar1 = dd;
       }
-      if (labs(dd - timelastchar1) > 65536L) {
+      if (abs(dd - timelastchar1) > 65536L) {
         timelastchar1 -= static_cast<int>(floor(SECONDS_PER_DAY * 18.2));
       }
       if ((dd - timelastchar1) > tv1 && !beepyet) {
@@ -157,7 +157,7 @@ char getkey() {
         bputch(CG);
       }
       application()->UpdateShutDownStatus();
-      if (labs(dd - timelastchar1) > tv) {
+      if (abs(dd - timelastchar1) > tv) {
         bout.nl();
         bout << "Call back later when you are there.\r\n";
         hangup = true;

--- a/bbs/connect1.cpp
+++ b/bbs/connect1.cpp
@@ -338,12 +338,8 @@ void read_contacts() {
 void set_net_num(int nNetworkNumber) {
   if (nNetworkNumber >= 0 && nNetworkNumber < session()->GetMaxNetworkNumber()) {
     session()->SetNetworkNumber(nNetworkNumber);
-    //session()->pszNetworkName = net_networks[session()->GetNetworkNumber()].name;
-    //session()->pszNetworkDataDir = net_networks[session()->GetNetworkNumber()].dir;
     net_sysnum = net_networks[session()->GetNetworkNumber()].sysnum;
     session()->SetCurrentNetworkType(net_networks[ session()->GetNetworkNumber() ].type);
-
-    application()->networkNumEnvVar = StringPrintf("WWIV_NET=%d", session()->GetNetworkNumber());
   }
 }
 

--- a/bbs/crc.cpp
+++ b/bbs/crc.cpp
@@ -118,6 +118,7 @@ static UNS_32_BITS crc_32_tab[] = {
 
 #define UPDC32(octet, crc) (crc_32_tab[((crc) ^ (octet)) & 0xff] ^ ((crc) >> 8))
 
+unsigned short crc;
 
 unsigned long int crc32buf(const char *pBuffer, std::size_t nLength) {
   unsigned long int oldcrc32;

--- a/bbs/crc.h
+++ b/bbs/crc.h
@@ -22,4 +22,7 @@
 
 unsigned long int crc32buf(const char *pBuffer, std::size_t nLength);
 
+// used by old sr.cpp and friends.
+extern unsigned short crc;
+
 #endif  // __INCLUDED_BBS_CRC_H__

--- a/bbs/datetime.cpp
+++ b/bbs/datetime.cpp
@@ -16,6 +16,9 @@
 /*    language governing permissions and limitations under the License.   */
 /*                                                                        */
 /**************************************************************************/
+// Always declare wwiv_windows.h first to avoid collisions on defines.
+#include "bbs/wwiv_windows.h"
+
 #include "bbs/datetime.h"
 #include "bbs/wconstants.h"
 #include "bbs/wwiv.h"

--- a/bbs/defaults.cpp
+++ b/bbs/defaults.cpp
@@ -978,8 +978,8 @@ static long is_inscan(int dir) {
 }
 
 void config_scan_plus(int type) {
-  int i, command, this_dir, this_sub, ad;
-  int sysdir = 0, top = 0, amount = 0, pos = 0, side_pos = 0;
+  int i, command;
+  int top = 0, amount = 0, pos = 0, side_pos = 0;
   side_menu_colors smc = {
     NORMAL_HIGHLIGHT,
     NORMAL_MENU_ITEM,
@@ -1069,30 +1069,30 @@ void config_scan_plus(int type) {
                  qsc_q[usub[top + pos].subnum / 32] & (1L << (usub[top + pos].subnum % 32)));
         redraw = false;
         break;
-      case SPACE:
+      case SPACE: {
         if (type == 0) {
 #ifdef NOTOGGLESYSOP
           if (usub[top + pos].subnum == 0) {
             qsc_q[usub[top + pos].subnum / 32] |= (1L << (usub[top + pos].subnum % 32));
-          } else
+          }
+          else
 #endif
             qsc_q[usub[top + pos].subnum / 32] ^= (1L << (usub[top + pos].subnum % 32));
-        } else {
-          if (IsEquals(udir[0].keys, "0")) {
-            sysdir = 1;
-          }
-          for (this_dir = 0; (this_dir < session()->num_dirs); this_dir++) {
+        }
+        else {
+          bool sysdir = IsEquals(udir[0].keys, "0");
+          for (int this_dir = 0; (this_dir < session()->num_dirs); this_dir++) {
             const string s = StringPrintf("%d", sysdir ? top + pos : top + pos + 1);
             if (s == udir[this_dir].keys) {
-              ad = udir[this_dir].subnum;
+              int ad = udir[this_dir].subnum;
               qsc_n[ad / 32] ^= (1L << (ad % 32));
             }
           }
         }
         drawscan(pos, type ? is_inscan(top + pos) :
-                 qsc_q[usub[top + pos].subnum / 32] & (1L << (usub[top + pos].subnum % 32)));
+          qsc_q[usub[top + pos].subnum / 32] & (1L << (usub[top + pos].subnum % 32)));
         redraw = false;
-        break;
+      } break;
       case EXECUTE:
         if (!useconf && side_pos > 5) {
           side_pos += 2;
@@ -1127,15 +1127,11 @@ void config_scan_plus(int type) {
           if (type == 0) {
             qsc_q[usub[top + pos].subnum / 32] ^= (1L << (usub[top + pos].subnum % 32));
           } else {
-            int sysdir = 0;
-            int ad;
-            if (IsEquals(udir[0].keys, "0")) {
-              sysdir = 1;
-            }
+            bool sysdir = IsEquals(udir[0].keys, "0");
             for (int this_dir = 0; (this_dir < session()->num_dirs); this_dir++) {
               const string s = StringPrintf("%d", sysdir ? top + pos : top + pos + 1);
               if (s == udir[this_dir].keys) {
-                ad = udir[this_dir].subnum;
+                int ad = udir[this_dir].subnum;
                 qsc_n[ad / 32] ^= (1L << (ad % 32));
               }
             }
@@ -1146,13 +1142,13 @@ void config_scan_plus(int type) {
           break;
         case 3:
           if (type == 0) {
-            for (this_sub = 0; this_sub < session()->num_subs; this_sub++) {
+            for (int this_sub = 0; this_sub < session()->num_subs; this_sub++) {
               if (qsc_q[usub[this_sub].subnum / 32] & (1L << (usub[this_sub].subnum % 32))) {
                 qsc_q[usub[this_sub].subnum / 32] ^= (1L << (usub[this_sub].subnum % 32));
               }
             }
           } else {
-            for (this_dir = 0; this_dir < session()->num_dirs; this_dir++) {
+            for (int this_dir = 0; this_dir < session()->num_dirs; this_dir++) {
               if (qsc_n[udir[this_dir].subnum / 32] & (1L << (udir[this_dir].subnum % 32))) {
                 qsc_n[udir[this_dir].subnum / 32] ^= 1L << (udir[this_dir].subnum % 32);
               }
@@ -1164,13 +1160,13 @@ void config_scan_plus(int type) {
           break;
         case 4:
           if (type == 0) {
-            for (this_sub = 0; this_sub < session()->num_subs; this_sub++) {
+            for (int this_sub = 0; this_sub < session()->num_subs; this_sub++) {
               if (!(qsc_q[usub[this_sub].subnum / 32] & (1L << (usub[this_sub].subnum % 32)))) {
                 qsc_q[usub[this_sub].subnum / 32] ^= (1L << (usub[this_sub].subnum % 32));
               }
             }
           } else {
-            for (this_dir = 0; this_dir < session()->num_dirs; this_dir++) {
+            for (int this_dir = 0; this_dir < session()->num_dirs; this_dir++) {
               if (!(qsc_n[udir[this_dir].subnum / 32] & (1L << (udir[this_dir].subnum % 32)))) {
                 qsc_n[udir[this_dir].subnum / 32] ^= 1L << (udir[this_dir].subnum % 32);
               }

--- a/bbs/defaults.cpp
+++ b/bbs/defaults.cpp
@@ -1127,12 +1127,12 @@ void config_scan_plus(int type) {
           if (type == 0) {
             qsc_q[usub[top + pos].subnum / 32] ^= (1L << (usub[top + pos].subnum % 32));
           } else {
-            int this_dir, sysdir = 0;
+            int sysdir = 0;
             int ad;
             if (IsEquals(udir[0].keys, "0")) {
               sysdir = 1;
             }
-            for (this_dir = 0; (this_dir < session()->num_dirs); this_dir++) {
+            for (int this_dir = 0; (this_dir < session()->num_dirs); this_dir++) {
               const string s = StringPrintf("%d", sysdir ? top + pos : top + pos + 1);
               if (s == udir[this_dir].keys) {
                 ad = udir[this_dir].subnum;

--- a/bbs/inmsg.cpp
+++ b/bbs/inmsg.cpp
@@ -506,18 +506,18 @@ void UpdateMessageBufferTheadsInfo(char *pszMessageBuffer, long *plBufferLength,
   if (!IsEqualsIgnoreCase(aux, "email")) {
     long msgid = time(nullptr);
     long targcrc = crc32buf(pszMessageBuffer, strlen(pszMessageBuffer));
-    const string buf = StringPrintf("%c0P %lX-%lX", 4, targcrc, msgid);
-    AddLineToMessageBuffer(pszMessageBuffer, buf, plBufferLength);
+    const string msgid_buf = StringPrintf("%c0P %lX-%lX", 4, targcrc, msgid);
+    AddLineToMessageBuffer(pszMessageBuffer, msgid_buf, plBufferLength);
     if (thread) {
       thread [session()->GetNumMessagesInCurrentMessageArea() + 1 ].msg_num = static_cast< unsigned short>
           (session()->GetNumMessagesInCurrentMessageArea() + 1);
-      strcpy(thread[session()->GetNumMessagesInCurrentMessageArea() + 1].message_code, &buf.c_str()[4]);
+      strcpy(thread[session()->GetNumMessagesInCurrentMessageArea() + 1].message_code, &msgid_buf.c_str()[4]);
     }
     if (session()->threadID.length() > 0) {
-      const string buf = StringPrintf("%c0W %s", 4, session()->threadID.c_str());
-      AddLineToMessageBuffer(pszMessageBuffer, buf, plBufferLength);
+      const string threadid_buf = StringPrintf("%c0W %s", 4, session()->threadID.c_str());
+      AddLineToMessageBuffer(pszMessageBuffer, threadid_buf, plBufferLength);
       if (thread) {
-        strcpy(thread[session()->GetNumMessagesInCurrentMessageArea() + 1].parent_code, &buf.c_str()[4]);
+        strcpy(thread[session()->GetNumMessagesInCurrentMessageArea() + 1].parent_code, &threadid_buf.c_str()[4]);
         thread[ session()->GetNumMessagesInCurrentMessageArea() + 1 ].used = 1;
       }
     }

--- a/bbs/inmsg.cpp
+++ b/bbs/inmsg.cpp
@@ -504,8 +504,8 @@ void GetMessageTitle(string *title, bool force_title) {
 
 void UpdateMessageBufferTheadsInfo(char *pszMessageBuffer, long *plBufferLength, const char *aux) {
   if (!IsEqualsIgnoreCase(aux, "email")) {
-    long msgid = time(nullptr);
-    long targcrc = crc32buf(pszMessageBuffer, strlen(pszMessageBuffer));
+    time_t msgid = time(nullptr);
+    unsigned long targcrc = crc32buf(pszMessageBuffer, strlen(pszMessageBuffer));
     const string msgid_buf = StringPrintf("%c0P %lX-%lX", 4, targcrc, msgid);
     AddLineToMessageBuffer(pszMessageBuffer, msgid_buf, plBufferLength);
     if (thread) {
@@ -546,11 +546,11 @@ void UpdateMessageBufferInReplyToInfo(char *pszMessageBuffer, long *plBufferLeng
     }
   }
   if (irt[0] != '"') {
-    const string buf = StringPrintf("RE: %s", irt);
-    AddLineToMessageBuffer(pszMessageBuffer, buf, plBufferLength);
+    const string irt_buf = StringPrintf("RE: %s", irt);
+    AddLineToMessageBuffer(pszMessageBuffer, irt_buf, plBufferLength);
     if (irt_sub[0]) {
-      const string buf = StringPrintf("ON: %s", irt_sub);
-      AddLineToMessageBuffer(pszMessageBuffer, buf, plBufferLength);
+      const string irt_sub_buf = StringPrintf("ON: %s", irt_sub);
+      AddLineToMessageBuffer(pszMessageBuffer, irt_sub_buf, plBufferLength);
     }
   } else {
     irt_sub[0] = '\0';
@@ -558,8 +558,8 @@ void UpdateMessageBufferInReplyToInfo(char *pszMessageBuffer, long *plBufferLeng
 
   if (irt_name[0] &&
       !IsEqualsIgnoreCase(aux, "email")) {
-    const string buf = StringPrintf("BY: %s", irt_name);
-    AddLineToMessageBuffer(pszMessageBuffer, buf, plBufferLength);
+    const string irt_name_buf = StringPrintf("BY: %s", irt_name);
+    AddLineToMessageBuffer(pszMessageBuffer, irt_name_buf, plBufferLength);
   }
   AddLineToMessageBuffer(pszMessageBuffer, "", plBufferLength);
 }

--- a/bbs/instmsg.cpp
+++ b/bbs/instmsg.cpp
@@ -593,7 +593,7 @@ bool inst_msg_waiting() {
   }
 
   long l = timer1();
-  if (labs(l - last_iia) < iia) {
+  if (abs(l - last_iia) < iia) {
     return false;
   }
 

--- a/bbs/lilo.cpp
+++ b/bbs/lilo.cpp
@@ -257,7 +257,7 @@ static void ExecuteWWIVNetworkRequest() {
   }
 
   application()->GetStatusManager()->RefreshStatusCache();
-  long lTime = time(nullptr);
+  time_t lTime = time(nullptr);
   if (session()->usernum == -2) {
     std::stringstream networkCommand;
     networkCommand << "network /B" << modem_speed << " /T" << lTime << " /F0";
@@ -692,14 +692,13 @@ static void CheckAndUpdateUserInfo() {
              (session()->user()->GetExpiresDateNum() < static_cast<unsigned long>(lTime + 10 * SECS_PER_DAY))) {
     if (static_cast<int>((session()->user()->GetExpiresDateNum() - lTime) / static_cast<unsigned long>
                          (SECS_PER_DAY)) > 1) {
-      bout << "|#6Your registration expires in " <<
-                         static_cast<int>((session()->user()->GetExpiresDateNum() - lTime) / static_cast<unsigned long>
-                                          (SECS_PER_DAY))
-                         << " days";
+      bout << "|#6Your registration expires in "
+           << static_cast<int>((session()->user()->GetExpiresDateNum() - lTime) / static_cast<unsigned long>(SECS_PER_DAY))
+           << " days";
     } else {
-      bout << "|#6Your registration expires in " <<
-                         static_cast<int>((session()->user()->GetExpiresDateNum() - lTime) / static_cast<unsigned long>(3600L))
-                         << " hours.";
+      bout << "|#6Your registration expires in "
+           << static_cast<int>((session()->user()->GetExpiresDateNum() - lTime) / static_cast<unsigned long>(3600L))
+           << " hours.";
     }
     bout.nl(2);
     pausescr();

--- a/bbs/lilo.cpp
+++ b/bbs/lilo.cpp
@@ -992,7 +992,7 @@ void logoff() {
   if (g_flags & g_flag_scanned_files) {
     session()->user()->SetNewScanDateNumber(session()->user()->GetLastOnDateNumber());
   }
-  long lTime = time(nullptr);
+  time_t lTime = time(nullptr);
   session()->user()->SetLastOnDateNumber(lTime);
   sysoplogfi(false, "Read: %lu   Time on: %u", session()->GetNumMessagesReadThisLogon(),
              static_cast<int>((timer() - timeon) / MINUTES_PER_HOUR_FLOAT));

--- a/bbs/listplus.cpp
+++ b/bbs/listplus.cpp
@@ -793,10 +793,10 @@ int prep_search_rec(struct search_record * search_rec, int type) {
     }
   } else if (type == LP_NSCAN_DIR) {
     search_rec->alldirs = THIS_DIR;
-    search_rec->nscandate = nscandate;
+    search_rec->nscandate = static_cast<uint32_t>(nscandate);
   } else if (type == LP_NSCAN_NSCAN) {
     g_flags |= g_flag_scanned_files;
-    search_rec->nscandate = nscandate;
+    search_rec->nscandate = static_cast<uint32_t>(nscandate);
     search_rec->alldirs = ALL_DIRS;
   } else {
     sysoplog("Undef LP type");
@@ -1128,7 +1128,7 @@ void config_file_list() {
   strcpy(reinterpret_cast<char*>(u.upby), session()->user()->GetUserNameAndNumber(session()->usernum));
   u.numdloads = 50;
   u.numbytes = 655535L;
-  u.daten = time(nullptr) - 10000;
+  u.daten = static_cast<uint32_t>(time(nullptr) - 10000);
 
   load_lp_config();
 

--- a/bbs/local_io.h
+++ b/bbs/local_io.h
@@ -24,40 +24,6 @@
 #include "bbs/capture.h"
 #include "bbs/keycodes.h"
 #include "core/file.h"
-
-#ifdef _WIN32
-#define NOGDICAPMASKS
-#define NOSYSMETRICS
-#define NOMENUS
-#define NOICONS
-#define NOKEYSTATES
-#define NOSYSCOMMANDS
-#define NORASTEROPS
-#define NOATOM
-#define NOCLIPBOARD
-#define NODRAWTEXT
-#define NOKERNEL
-#define NONLS
-#define NOMEMMGR
-#define NOMETAFILE
-#define NOMINMAX
-#define NOOPENFILE
-#define NOSCROLL
-#define NOSERVICE
-#define NOSOUND
-#define NOTEXTMETRIC
-#define NOWH
-#define NOCOMM
-#define NOKANJI
-#define NOHELP
-#define NOPROFILER
-#define NODEFERWINDOWPOS
-#define NOMCX
-#define NOCRYPT
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-
-#endif // _WIN32
 // This C++ class should encompass all Local Input/Output from The BBS.
 // You should use a routine in here instead of using printf, puts, etc.
 

--- a/bbs/local_io_curses.cpp
+++ b/bbs/local_io_curses.cpp
@@ -355,6 +355,11 @@ void CursesLocalIO::skey(char ch) {
   }
 }
 
+#if defined( _MSC_VER )
+#pragma warning( push )
+#pragma warning( disable : 4125 4100 )
+#endif
+
 void CursesLocalIO::tleft(bool bCheckForTimeOut) {}
 
 static int last_key_pressed = ERR;
@@ -374,11 +379,11 @@ unsigned char CursesLocalIO::LocalGetChar() {
   if (last_key_pressed != ERR) {
     int ch = last_key_pressed;
     last_key_pressed = ERR;
-    return ch;
+    return static_cast<unsigned char>(ch);
   }
   nodelay(window_->window(), FALSE);
   last_key_pressed = ERR;
-  return window_->GetChar();
+  return static_cast<unsigned char>(window_->GetChar());
 }
 
 void CursesLocalIO::MakeLocalWindow(int x, int y, int xlen, int ylen) {}
@@ -395,8 +400,11 @@ void CursesLocalIO::LocalClrEol() {
 void CursesLocalIO::LocalWriteScreenBuffer(const char *pszBuffer) {}
 int CursesLocalIO::GetDefaultScreenBottom() { return window_->GetMaxY() - 1; }
 
-void CursesLocalIO::LocalEditLine(char *s, int len, int status, int *returncode, char *ss) {}
+void CursesLocalIO::LocalEditLine(char *s, int len, int edit_status, int *returncode, char *ss) {}
 
 void CursesLocalIO::UpdateNativeTitleBar() {}
 
 void CursesLocalIO::UpdateTopScreen(WStatus* pStatus, WSession *pSession, int nInstanceNumber) {}
+#if defined( _MSC_VER )
+#pragma warning( pop )
+#endif // _MSC_VER

--- a/bbs/local_io_curses.cpp
+++ b/bbs/local_io_curses.cpp
@@ -73,7 +73,7 @@ static std::map<int, AnsiColor> CreateAnsiScheme() {
 
   // Create the color pairs for each of the colors defined in the color scheme.
   for (const auto& kv : scheme) {
-    init_pair(kv.first + 100, kv.second.f(), kv.second.b());
+    init_pair(static_cast<short>(kv.first + 100), kv.second.f(), kv.second.b());
   }
   return scheme;
 }
@@ -124,7 +124,6 @@ void CursesLocalIO::LocalLf() {
 }
 
 void CursesLocalIO::LocalCr() {
-  int x = WhereX();
   int y = WhereY();
   window_->GotoXY(0, y);
 }

--- a/bbs/local_io_curses.h
+++ b/bbs/local_io_curses.h
@@ -47,6 +47,10 @@ private:
   bool bold_;
 };
 
+#if defined( _MSC_VER )
+#pragma warning( push )
+#pragma warning( disable : 4100 )
+#endif
 
 class CursesLocalIO : public LocalIO {
  public:
@@ -100,5 +104,8 @@ private:
   const std::map<int, AnsiColor> scheme_;
 };
 
+#if defined( _MSC_VER )
+#pragma warning( pop )
+#endif // _MSC_VER
 
 #endif // __INCLUDED_LOCAL_IO_CURSES_H__

--- a/bbs/local_io_win32.cpp
+++ b/bbs/local_io_win32.cpp
@@ -137,7 +137,6 @@ int Win32ConsoleIO::WhereX() {
     return capture_->wx();
   }
 
-  CONSOLE_SCREEN_BUFFER_INFO m_consoleBufferInfo;
   GetConsoleScreenBufferInfo(m_hConOut, &m_consoleBufferInfo);
 
   m_cursorPosition.X = m_consoleBufferInfo.dwCursorPosition.X;
@@ -152,13 +151,9 @@ int Win32ConsoleIO::WhereX() {
 * the cursor is at the top-most position it can be at.
 */
 int Win32ConsoleIO::WhereY() {
-  CONSOLE_SCREEN_BUFFER_INFO m_consoleBufferInfo;
-
   GetConsoleScreenBufferInfo(m_hConOut, &m_consoleBufferInfo);
-
   m_cursorPosition.X = m_consoleBufferInfo.dwCursorPosition.X;
   m_cursorPosition.Y = m_consoleBufferInfo.dwCursorPosition.Y;
-
   return m_cursorPosition.Y - GetTopLine();
 }
 

--- a/bbs/local_io_win32.h
+++ b/bbs/local_io_win32.h
@@ -18,6 +18,8 @@
 /**************************************************************************/
 #ifndef __INCLUDED_LOCAL_IO_WIN32_H__
 #define __INCLUDED_LOCAL_IO_WIN32_H__
+// Always declare wwiv_windows.h first to avoid collisions on defines.
+#include "bbs/wwiv_windows.h"
 
 #include <string>
 
@@ -26,39 +28,6 @@
 #include "bbs/local_io.h"
 #include "core/file.h"
 
-#ifdef _WIN32
-#define NOGDICAPMASKS
-#define NOSYSMETRICS
-#define NOMENUS
-#define NOICONS
-#define NOKEYSTATES
-#define NOSYSCOMMANDS
-#define NORASTEROPS
-#define NOATOM
-#define NOCLIPBOARD
-#define NODRAWTEXT
-#define NOKERNEL
-#define NONLS
-#define NOMEMMGR
-#define NOMETAFILE
-#define NOMINMAX
-#define NOOPENFILE
-#define NOSCROLL
-#define NOSERVICE
-#define NOSOUND
-#define NOTEXTMETRIC
-#define NOWH
-#define NOCOMM
-#define NOKANJI
-#define NOHELP
-#define NOPROFILER
-#define NODEFERWINDOWPOS
-#define NOMCX
-#define NOCRYPT
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-
-#endif // _WIN32
 // This C++ class should encompass all Local Input/Output from The BBS.
 // You should use a routine in here instead of using printf, puts, etc.
 

--- a/bbs/misccmd.cpp
+++ b/bbs/misccmd.cpp
@@ -95,8 +95,7 @@ void kill_old_email() {
           bout << "#" << m.tosys << " @" << m.tosys << wwiv::endl;
         }
         bout.bprintf("|#1Subj|#9: |#%d%60.60s\r\n", session()->GetMessageColor(), m.title);
-        time_t lCurrentTime;
-        time(&lCurrentTime);
+        time_t lCurrentTime = time(nullptr);
         int nDaysAgo = static_cast<int>((lCurrentTime - m.daten) / HOURS_PER_DAY_FLOAT / SECONDS_PER_HOUR_FLOAT);
         bout << "|#1Sent|#9: |#" << session()->GetMessageColor() << nDaysAgo << " days ago" << wwiv::endl;
         if (m.status & status_file) {

--- a/bbs/netsup.cpp
+++ b/bbs/netsup.cpp
@@ -285,7 +285,7 @@ void do_callout(int sn) {
   if (i != -1) {
     net_system_list_rec *csne = next_system(net_networks[session()->GetNetworkNumber()].con[i].sysnum);
     if (csne) {
-      sprintf(s, "network /N%u /A%s /P%s /S%u /T%ld",
+      sprintf(s, "network /N%u /A%s /P%s /S%u /T%lld",
               sn, (net_networks[session()->GetNetworkNumber()].con[i].options & options_sendback) ? "1" : "0",
               csne->phone, 0, tCurrentTime);
       if (net_networks[session()->GetNetworkNumber()].con[i].macnum) {
@@ -462,7 +462,7 @@ void attempt_callout() {
   if (last_time_c > tCurrentTime) {
     last_time_c = 0L;
   }
-  if (labs(last_time_c - tCurrentTime) < 120) {
+  if (abs(last_time_c - tCurrentTime) < 120) {
     return;
   }
   if (last_time_c == 0L) {
@@ -532,14 +532,14 @@ void attempt_callout() {
           }
         }
         if (con[i].options & options_once_per_day) {
-          if (labs(tCurrentTime - ncn[i2].lastcontactsent) <
+          if (abs(tCurrentTime - ncn[i2].lastcontactsent) <
               (20L * SECONDS_PER_HOUR / con[i].times_per_day)) {
             ok = false;
           }
         }
         if (ok) {
           if ((bytes_to_k(ncn[i2].bytes_waiting) < con[i].min_k)
-              && (labs(tCurrentTime - ncn[i2].lastcontact) < SECONDS_PER_DAY)) {
+              && (abs(tCurrentTime - ncn[i2].lastcontact) < SECONDS_PER_DAY)) {
             ok = false;
           }
         }
@@ -675,14 +675,14 @@ void print_pending_list() {
           strcpy(s2, "|#3---");
         }
 
-        int h = 0, m = 0;
+        time_t h = 0, m = 0;
         if (ncn[i2].lastcontactsent) {
           time_t tLastContactTime = tCurrentTime - ncn[i2].lastcontactsent;
-          int se = tLastContactTime % 60;
+          time_t se = tLastContactTime % 60;
           tLastContactTime = (tLastContactTime - se) / 60;
-          m = tLastContactTime % 60;
-          h = tLastContactTime / 60;
-          sprintf(s1, "|#2%02d:%02d:%02d", h, m, se);
+          m = static_cast<int32_t>(tLastContactTime % 60);
+          h = static_cast<int32_t>(tLastContactTime / 60);
+          sprintf(s1, "|#2%02lld:%02lld:%02lld", h, m, se);
         } else {
           strcpy(s1, "   |#6NEVER!    ");
         }
@@ -704,7 +704,7 @@ void print_pending_list() {
         if (m >= 30) {
           h++;
         }
-        i3 = ((con[i1].call_x_days * 24) - h - adjust);
+        i3 = ((con[i1].call_x_days * 24) - static_cast<int>(h) - adjust);
         if (m < 31) {
           h--;
         }
@@ -937,9 +937,9 @@ static void print_call(int sn, int nNetNumber, int i2) {
   session()->localIO()->LocalXYAPrintf(23, 18, color, "%-10.16s", s1);
 
   if (ncn[i2].firstcontact) {
-    sprintf(s1, "%ld:", (tCurrentTime - ncn[i2].firstcontact) / SECONDS_PER_HOUR);
+    sprintf(s1, "%ld:", static_cast<uint32_t>(tCurrentTime - ncn[i2].firstcontact) / SECONDS_PER_HOUR);
     time_t tTime = (((tCurrentTime - ncn[i2].firstcontact) % SECONDS_PER_HOUR) / 60);
-    sprintf(s, "%ld", tTime);
+    sprintf(s, "%lld", tTime);
     if (tTime < 10) {
       strcat(s1, "0");
       strcat(s1, s);
@@ -953,9 +953,9 @@ static void print_call(int sn, int nNetNumber, int i2) {
   session()->localIO()->LocalXYAPrintf(23, 16, color, "%-17.16s", s1);
 
   if (ncn[i2].lastcontactsent) {
-    sprintf(s1, "%ld:", (tCurrentTime - ncn[i2].lastcontactsent) / SECONDS_PER_HOUR);
+    sprintf(s1, "%ld:", static_cast<uint32_t>(tCurrentTime - ncn[i2].lastcontactsent) / SECONDS_PER_HOUR);
     time_t tTime = (((tCurrentTime - ncn[i2].lastcontactsent) % SECONDS_PER_HOUR) / 60);
-    sprintf(s, "%ld", tTime);
+    sprintf(s, "%lld", tTime);
     if (tTime < 10) {
       strcat(s1, "0");
       strcat(s1, s);
@@ -969,9 +969,9 @@ static void print_call(int sn, int nNetNumber, int i2) {
   session()->localIO()->LocalXYAPrintf(58, 16, color, "%-17.16s", s1);
 
   if (ncn[i2].lasttry) {
-    sprintf(s1, "%ld:", (tCurrentTime - ncn[i2].lasttry) / SECONDS_PER_HOUR);
+    sprintf(s1, "%ld:", static_cast<uint32_t>(tCurrentTime - ncn[i2].lasttry) / SECONDS_PER_HOUR);
     time_t tTime = (((tCurrentTime - ncn[i2].lasttry) % SECONDS_PER_HOUR) / 60);
-    sprintf(s, "%ld", tTime);
+    sprintf(s, "%lld", tTime);
     if (tTime < 10) {
       strcat(s1, "0");
       strcat(s1, s);

--- a/bbs/normupld.cpp
+++ b/bbs/normupld.cpp
@@ -125,8 +125,7 @@ void normalupload(int dn) {
   char szReceiveFileName[ MAX_PATH ];
   sprintf(szReceiveFileName, "%s%s", d.path, szUnalignedFile);
   if (ok && yesno()) {
-    File file(d.path, szUnalignedFile);
-    if (file.Exists()) {
+    if (File::Exists(d.path, szUnalignedFile)) {
       if (dcs()) {
         xfer = false;
         bout.nl(2);
@@ -152,9 +151,8 @@ void normalupload(int dn) {
         bout << "This directory is for Public Domain/\r\nShareware programs ONLY.  Please do not\r\n";
         bout << "upload other programs.  If you have\r\ntrouble with this policy, please contact\r\n";
         bout << "the sysop.\r\n\n";
-        char szBuffer[ 255 ];
-        sprintf(szBuffer , "Wanted to upload \"%s\"", u.filename);
-        add_ass(5, szBuffer);
+        const string message = StringPrintf("Wanted to upload \"%s\"", u.filename);
+        add_ass(5, message.c_str());
         ok = 0;
       } else {
         u.mask = mask_PD;

--- a/bbs/normupld.cpp
+++ b/bbs/normupld.cpp
@@ -274,8 +274,8 @@ void normalupload(int dn) {
           FileAreaSetRecord(fileDownload, 0);
           fileDownload.Read(&u1, sizeof(uploadsrec));
           u1.numbytes = session()->numf;
-          u1.daten = lCurrentTime;
-          session()->m_DirectoryDateCache[dn] = lCurrentTime;
+          u1.daten = static_cast<uint32_t>(lCurrentTime);
+          session()->m_DirectoryDateCache[dn] = static_cast<uint32_t>(lCurrentTime);
           FileAreaSetRecord(fileDownload, 0);
           fileDownload.Write(&u1, sizeof(uploadsrec));
           fileDownload.Close();

--- a/bbs/null_local_io.h
+++ b/bbs/null_local_io.h
@@ -21,6 +21,11 @@
 
 #include <string>
 
+#if defined( _MSC_VER )
+#pragma warning( push )
+#pragma warning( disable : 4125 )
+#endif
+
 class NullLocalIO : public LocalIO {
 public:
   NullLocalIO();
@@ -59,5 +64,10 @@ public:
 
   std::string* captured_;
 };
+
+#if defined( _MSC_VER )
+#pragma warning( pop )
+#endif // _MSC_VER
+
 
 #endif  // __INCLUDED_BBS_NULL_LOCAL_IO_H__

--- a/bbs/null_local_io.h
+++ b/bbs/null_local_io.h
@@ -23,7 +23,7 @@
 
 #if defined( _MSC_VER )
 #pragma warning( push )
-#pragma warning( disable : 4125, 4100 )
+#pragma warning( disable : 4125 4100 )
 #endif
 
 class NullLocalIO : public LocalIO {
@@ -52,13 +52,13 @@ public:
   virtual void tleft(bool bCheckForTimeOut) override {}
   virtual bool LocalKeyPressed() override { return false; }
   virtual void SaveCurrentLine(char *cl, char *atr, char *xl, char *cc) override {}
-  virtual unsigned char LocalGetChar() override { return getchar(); }
+  virtual unsigned char LocalGetChar() override { return static_cast<unsigned char>(getchar()); }
   virtual void MakeLocalWindow(int x, int y, int xlen, int ylen) override {}
   virtual void SetCursor(int cursorStyle) override {}
   virtual void LocalClrEol() override {}
   virtual void LocalWriteScreenBuffer(const char *pszBuffer) override {}
   virtual int GetDefaultScreenBottom() override { return 24; }
-  virtual void LocalEditLine(char *s, int len, int status, int *returncode, char *ss) override {}
+  virtual void LocalEditLine(char *s, int len, int statusx, int *returncode, char *ss) override {}
   virtual void UpdateNativeTitleBar() override {}
   virtual void UpdateTopScreen(WStatus* pStatus, WSession *pSession, int nInstanceNumber) override {}
 

--- a/bbs/null_local_io.h
+++ b/bbs/null_local_io.h
@@ -23,7 +23,7 @@
 
 #if defined( _MSC_VER )
 #pragma warning( push )
-#pragma warning( disable : 4125 )
+#pragma warning( disable : 4125, 4100 )
 #endif
 
 class NullLocalIO : public LocalIO {

--- a/bbs/pause.cpp
+++ b/bbs/pause.cpp
@@ -78,7 +78,7 @@ static char GetKeyForPause() {
 }
 // This will pause output, displaying the [PAUSE] message, and wait a key to be hit.
 void pausescr() {
-  int i1, i3, warned;
+  int i1, warned;
   int i = 0;
   char s[81];
   char ch;
@@ -140,7 +140,7 @@ void pausescr() {
         } else {
           if (ttotal > 180) {
             bputch(CG);
-            for (i3 = 0; i3 < i1; i3++) {
+            for (int i3 = 0; i3 < i1; i3++) {
               bputch(' ');
             }
             bout << "\x1b[" << i1 << "D";
@@ -154,7 +154,7 @@ void pausescr() {
       }
       ch = GetKeyForPause();
     } while (!ch && !hangup);
-    for (i3 = 0; i3 < i1; i3++) {
+    for (int i3 = 0; i3 < i1; i3++) {
       bputch(' ');
     }
     bout << "\x1b[" << i1 << "D";

--- a/bbs/platform/win32/InternalTelnetServer.cpp
+++ b/bbs/platform/win32/InternalTelnetServer.cpp
@@ -16,8 +16,8 @@
 /*    language governing permissions and limitations under the License.   */
 /*                                                                        */
 /**************************************************************************/
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+// Always declare wwiv_windows.h first to avoid collisions on defines.
+#include "bbs/wwiv_windows.h"
 
 #include "InternalTelnetServer.h"
 #include "Runnable.h"

--- a/bbs/platform/win32/exec.cpp
+++ b/bbs/platform/win32/exec.cpp
@@ -149,7 +149,7 @@ bool DoSyncFosLoopNT(HANDLE hProcess, HANDLE hSyncHangupEvent, HANDLE hSyncReadS
 #if 1
       int nLp = 0;
       for (nLp = 0; nLp < nNumReadFromComm; nLp++) {
-        fprintf(hLogFile, "[%u]", static_cast<unsigned char>(szReadBuffer[ nLp ]), (unsigned char) szReadBuffer[ nLp ]);
+        fprintf(hLogFile, "[%u]", static_cast<unsigned char>(szReadBuffer[ nLp ]));
       }
       fprintf(hLogFile, "   ");
       for (nLp = 0; nLp < nNumReadFromComm; nLp++) {

--- a/bbs/platform/win32/exec.cpp
+++ b/bbs/platform/win32/exec.cpp
@@ -16,8 +16,8 @@
 /*    language governing permissions and limitations under the License.   */
 /*                                                                        */
 /**************************************************************************/
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+// Always declare wwiv_windows.h first to avoid collisions on defines.
+#include "bbs/wwiv_windows.h"
 
 #include <algorithm>
 #include <ctime>
@@ -26,13 +26,13 @@
 
 #include "bbs/bbs.h"
 #include "bbs/wcomm.h"
-#include "core/File.h"
 #include "bbs/platform/platformfcns.h"
-#include "core/strings.h"
 #include "bbs/sysoplog.h"
-#include "core/textfile.h"
 #include "bbs/wsession.h"
 #include "bbs/vars.h"
+#include "core/File.h"
+#include "core/strings.h"
+#include "core/textfile.h"
 
 
 // from com.cpp.

--- a/bbs/platform/win32/utility2.cpp
+++ b/bbs/platform/win32/utility2.cpp
@@ -63,7 +63,7 @@ void WWIV_make_abs_cmd(const std::string root, std::string* out) {
       }
     }
   } else if (s1[0] == '\\') {
-    _snprintf(s1, sizeof(s1), "%c:%s", root.c_str(), out->c_str());
+    _snprintf(s1, sizeof(s1), "%c:%s", root.front(), out->c_str());
   } else {
     strncpy(s2, s1, sizeof(s2));
     strtok(s2, " \t");

--- a/bbs/platform/win32/wiot.cpp
+++ b/bbs/platform/win32/wiot.cpp
@@ -410,12 +410,12 @@ void WIOTelnet::HandleTelnetIAC(unsigned char nCmd, unsigned char nParam) {
   }
   break;
   case TELNET_OPTION_DO: {
-    const string s = StringPrintf("[Command: %s] [Option: {%d}]\n", "TELNET_OPTION_DO", nParam);
-    ::OutputDebugString(s.c_str());
+    const string do_s = StringPrintf("[Command: %s] [Option: {%d}]\n", "TELNET_OPTION_DO", nParam);
+    ::OutputDebugString(do_s.c_str());
     switch (nParam) {
     case TELNET_OPTION_SUPPRESSS_GA: {
-      const string s = StringPrintf("%c%c%c", TELNET_OPTION_IAC, TELNET_OPTION_WILL, TELNET_OPTION_SUPPRESSS_GA);
-      write(s.c_str(), 3, true);
+      const string will_s = StringPrintf("%c%c%c", TELNET_OPTION_IAC, TELNET_OPTION_WILL, TELNET_OPTION_SUPPRESSS_GA);
+      write(will_s.c_str(), 3, true);
       ::OutputDebugString("Sent TELNET IAC WILL SUPPRESSS GA\r\n");
     }
     break;
@@ -423,8 +423,8 @@ void WIOTelnet::HandleTelnetIAC(unsigned char nCmd, unsigned char nParam) {
   }
   break;
   case TELNET_OPTION_DONT: {
-    const string s = StringPrintf("[Command: %s] [Option: {%d}]\n", "TELNET_OPTION_DONT", nParam);
-    ::OutputDebugString(s.c_str());
+    const string dont_s = StringPrintf("[Command: %s] [Option: {%d}]\n", "TELNET_OPTION_DONT", nParam);
+    ::OutputDebugString(dont_s.c_str());
   }
   break;
   }

--- a/bbs/prot/zmwwiv.cpp
+++ b/bbs/prot/zmwwiv.cpp
@@ -16,6 +16,9 @@
 /*    language governing permissions and limitations under the License.   */
 /*                                                                        */
 /**************************************************************************/
+// Always declare wwiv_windows.h first to avoid collisions on defines.
+#include "bbs/wwiv_windows.h"
+
 #include <chrono>
 #include <cstdarg>
 #include <cstdlib>

--- a/bbs/qwk.cpp
+++ b/bbs/qwk.cpp
@@ -65,7 +65,7 @@ static int qwk_percent;
 static uint16_t max_msgs;
 
 // from xfer.cpp
-extern int this_date;
+extern uint32_t this_date;
 
 #ifndef _WIN32
 long filelength(int handle) {
@@ -116,7 +116,7 @@ void build_qwk_packet(void) {
   }
 
   if (!qwk_cfg.fu) {
-    qwk_cfg.fu = time(nullptr);
+    qwk_cfg.fu = static_cast<int32_t>(time(nullptr));
   }
 
   ++qwk_cfg.timesd;

--- a/bbs/qwk.h
+++ b/bbs/qwk.h
@@ -175,7 +175,7 @@ void ready_reply_packet(const char *packet_name, const char *msg_name);
 void make_text_ready(char *text, long len);
 char* make_text_file(int filenumber, long *size, int curpos, int blocks);
 void qwk_email_text(char *text, long size, char *title, char *to);
-void qwk_inmsg(const char *text, long size, messagerec *m1, const char *aux, const char *name, long thetime);
+void qwk_inmsg(const char *text, long size, messagerec *m1, const char *aux, const char *name, time_t thetime);
 void process_reply_dat(char *name);
 void qwk_post_text(char *text, long size, char *title, int sub);
 int find_qwk_sub(struct qwk_sub_conf *subs, int amount, int fromsub);

--- a/bbs/qwk1.cpp
+++ b/bbs/qwk1.cpp
@@ -331,7 +331,7 @@ void upload_reply_packet(void) {
   read_qwk_cfg(&qwk_cfg);
 
   if (!qwk_cfg.fu) {
-    qwk_cfg.fu = time(nullptr);
+    qwk_cfg.fu = static_cast<int32_t>(time(nullptr));
   }
 
   ++qwk_cfg.timesu;
@@ -428,7 +428,6 @@ char* make_text_file(int filenumber, long *size, int curpos, int blocks) {
 
 void qwk_email_text(char *text, long size, char *title, char *to) {
   int sy, un;
-  long thetime;
 
   strupr(to);
 
@@ -531,8 +530,7 @@ void qwk_email_text(char *text, long size, char *title, char *to) {
     }
 
     msg.storage_type = EMAIL_STORAGE;
-
-    time(&thetime);
+    time_t thetime = time(nullptr);
 
     const char* nam1 = session()->user()->GetUserNameNumberAndSystem(session()->usernum, net_sysnum);
     qwk_inmsg(text, size, &msg, "email", nam1, thetime);
@@ -546,7 +544,7 @@ void qwk_email_text(char *text, long size, char *title, char *to) {
   }
 }
 
-void qwk_inmsg(const char *text, long size, messagerec *m1, const char *aux, const char *name, long thetime) {
+void qwk_inmsg(const char *text, long size, messagerec *m1, const char *aux, const char *name, time_t thetime) {
   char s[181];
   int oiia = iia;
   setiia(0);
@@ -716,7 +714,6 @@ void qwk_post_text(char *text, long size, char *title, int sub) {
 
   int i, dm, f, done = 0, pass = 0;
   slrec ss;
-  long thetime;
   char user_name[101];
   uint8_t a;
 
@@ -855,7 +852,7 @@ void qwk_post_text(char *text, long size, char *title, int sub) {
     strcpy(user_name, nam1);
   }
 
-  time(&thetime);
+  time_t thetime = time(nullptr);
   qwk_inmsg(text, size, &m, subboards[session()->GetCurrentReadMessageArea()].filename, user_name, thetime);
 
   if (m.stored_as != 0xffffffff) {

--- a/bbs/qwk1.cpp
+++ b/bbs/qwk1.cpp
@@ -893,7 +893,8 @@ void qwk_post_text(char *text, long size, char *title, int sub) {
       p.qscan = pStatus->IncrementQScanPointer();
       application()->GetStatusManager()->CommitTransaction(pStatus);
     }
-    time((long *)(&p.daten));
+    time_t now = time(nullptr);
+    p.daten = static_cast<uint32_t>(now);
     if (session()->user()->data.restrict & restrict_validate) {
       p.status = status_unvalidated;
     } else {

--- a/bbs/sr.cpp
+++ b/bbs/sr.cpp
@@ -20,12 +20,14 @@
 #include <cmath>
 #include <string>
 
-#include "bbs/datetime.h"
-#include "bbs/wwiv.h"
-#include "bbs/stuffin.h"
 #include "core/strings.h"
+
+#include "bbs/crc.h"
+#include "bbs/datetime.h"
+#include "bbs/stuffin.h"
 #include "bbs/keycodes.h"
 #include "bbs/wconstants.h"
+#include "bbs/wwiv.h"
 
 using std::string;
 

--- a/bbs/srrcv.cpp
+++ b/bbs/srrcv.cpp
@@ -19,11 +19,13 @@
 #include <cmath>
 #include <string>
 
+#include "bbs/crc.h"
 #include "bbs/datetime.h"
-#include "bbs/wwiv.h"
-#include "bbs/wcomm.h"
-#include "core/strings.h"
 #include "bbs/keycodes.h"
+#include "bbs/wcomm.h"
+#include "bbs/wwiv.h"
+
+#include "core/strings.h"
 
 using std::string;
 

--- a/bbs/srsend.cpp
+++ b/bbs/srsend.cpp
@@ -18,10 +18,11 @@
 /**************************************************************************/
 #include <cmath>
 
+#include "bbs/crc.h"
 #include "bbs/datetime.h"
+#include "bbs/keycodes.h"
 #include "bbs/wcomm.h"
 #include "bbs/wwiv.h"
-#include "bbs/keycodes.h"
 #include "core/strings.h"
 
 using namespace wwiv::strings;

--- a/bbs/utility.cpp
+++ b/bbs/utility.cpp
@@ -210,7 +210,7 @@ void Wait(double d) {
   }
   const long lStartTime = timer1();
   auto l = d * 18.2;
-  while (labs(timer1() - lStartTime) < l) {
+  while (abs(timer1() - lStartTime) < l) {
     giveup_timeslice();
   }
 }

--- a/bbs/vars.h
+++ b/bbs/vars.h
@@ -108,7 +108,6 @@ __EXTRN__ unsigned short
 *csn_index,
 net_sysnum,
 #endif // NETWORK
-crc,
 *gat;
 
 __EXTRN__ int modem_speed;

--- a/bbs/wfc.cpp
+++ b/bbs/wfc.cpp
@@ -188,7 +188,7 @@ static void CleanNetIfNeeded() {
       session()->SetFileAreaCacheNumber(session()->GetFileAreaCacheNumber() + 1);
     } else {
       static int mult_time = 0;
-      if (application()->IsCleanNetNeeded() || labs(timer1() - mult_time) > 1000L) {
+      if (application()->IsCleanNetNeeded() || abs(timer1() - mult_time) > 1000L) {
         cleanup_net();
         mult_time = timer1();
       }

--- a/bbs/wfc.cpp
+++ b/bbs/wfc.cpp
@@ -126,15 +126,15 @@ static void DrawCommands(CursesWindow* commands) {
   commands->PutsXY(1, 7, "[U]serEdit [Y]-Log [Z]-Log");
 }
 
-static void DrawStatus(CursesWindow* status) {
-  status->SetColor(SchemeId::WINDOW_TEXT);
-  status->PutsXY(2, 1, "Today:");
-  status->PutsXY(2, 2, "Calls: XXXXX Minutes: XXXXX");
-  status->PutsXY(2, 3, "M: XXX L: XXX E: XXX F: XXX FW: XXX");
-  status->PutsXY(2, 4, "Totals:");
-  status->PutsXY(2, 5, "Users: XXXXX Calls: XXXXX");
-  status->PutsXY(2, 6, "Last User:");
-  status->PutsXY(2, 7, "XXXXXXXXXXXXXXXXXXXXXXXXXX");
+static void DrawStatus(CursesWindow* statusWindow) {
+  statusWindow->SetColor(SchemeId::WINDOW_TEXT);
+  statusWindow->PutsXY(2, 1, "Today:");
+  statusWindow->PutsXY(2, 2, "Calls: XXXXX Minutes: XXXXX");
+  statusWindow->PutsXY(2, 3, "M: XXX L: XXX E: XXX F: XXX FW: XXX");
+  statusWindow->PutsXY(2, 4, "Totals:");
+  statusWindow->PutsXY(2, 5, "Users: XXXXX Calls: XXXXX");
+  statusWindow->PutsXY(2, 6, "Last User:");
+  statusWindow->PutsXY(2, 7, "XXXXXXXXXXXXXXXXXXXXXXXXXX");
 }
 
 static string GetLastUserName(int inst_num) {
@@ -151,27 +151,27 @@ static string GetLastUserName(int inst_num) {
 
 }
 
-static void UpdateStatus(CursesWindow* status) {
-  status->SetColor(SchemeId::WINDOW_DATA);
+static void UpdateStatus(CursesWindow* statusWindow) {
+  statusWindow->SetColor(SchemeId::WINDOW_DATA);
   std::unique_ptr<WStatus> pStatus(application()->GetStatusManager()->GetStatus());
 
-  status->PrintfXY(9, 2, "%-5d", pStatus->GetNumCallsToday());
-  status->PrintfXY(24, 2, "%-5d", pStatus->GetMinutesActiveToday());
+  statusWindow->PrintfXY(9, 2, "%-5d", pStatus->GetNumCallsToday());
+  statusWindow->PrintfXY(24, 2, "%-5d", pStatus->GetMinutesActiveToday());
 
-  status->PrintfXY(5, 3, "%-3u", pStatus->GetNumMessagesPostedToday());
-  status->PrintfXY(12, 3, "%-3u", pStatus->GetNumLocalPosts());
-  status->PrintfXY(19, 3, "%-3u", pStatus->GetNumEmailSentToday());
-  status->PrintfXY(26, 3, "%-3u", pStatus->GetNumFeedbackSentToday());
+  statusWindow->PrintfXY(5, 3, "%-3u", pStatus->GetNumMessagesPostedToday());
+  statusWindow->PrintfXY(12, 3, "%-3u", pStatus->GetNumLocalPosts());
+  statusWindow->PrintfXY(19, 3, "%-3u", pStatus->GetNumEmailSentToday());
+  statusWindow->PrintfXY(26, 3, "%-3u", pStatus->GetNumFeedbackSentToday());
 
   fwaiting = session()->user()->GetNumMailWaiting();
-  status->PrintfXY(34, 3, "%-3d", fwaiting);
+  statusWindow->PrintfXY(34, 3, "%-3d", fwaiting);
 
-  status->PrintfXY(9, 5, "%-5d", pStatus->GetNumUsers());
-  status->PrintfXY(22, 5, "%-6lu", pStatus->GetCallerNumber());
+  statusWindow->PrintfXY(9, 5, "%-5d", pStatus->GetNumUsers());
+  statusWindow->PrintfXY(22, 5, "%-6lu", pStatus->GetCallerNumber());
 
   // TODO(rushfan): Need to know the last used node number
   // then call GetLastUserName.
-  //  status->PutsXY(2, 7, "XXXXXXXXXXXXXXXXXXXXXXXXXX");
+  //  statusWindow->PutsXY(2, 7, "XXXXXXXXXXXXXXXXXXXXXXXXXX");
 }
 
 static void CleanNetIfNeeded() {
@@ -492,8 +492,8 @@ void wfc_screen() {
   }
 }
 
-void DisplayWFCScreen(const char *pszScreenBuffer) {
-  session()->localIO()->LocalWriteScreenBuffer(pszScreenBuffer);
+void DisplayWFCScreen(const char *screenBuffer) {
+  session()->localIO()->LocalWriteScreenBuffer(screenBuffer);
 }
 
 #endif // __unix__

--- a/bbs/wuser.h
+++ b/bbs/wuser.h
@@ -750,11 +750,11 @@ class WUser {
   void SetDownloadK(unsigned long l)            {
     data.dk = l;
   }
-  const unsigned long GetLastOnDateNumber() const {
+  const uint32_t GetLastOnDateNumber() const {
     return data.daten;
   }
-  void SetLastOnDateNumber(unsigned long l)     {
-    data.daten = l;
+  void SetLastOnDateNumber(time_t l)     {
+    data.daten = static_cast<uint32_t>(l);
   }
   const unsigned long GetWWIVRegNumber() const    {
     return data.wwiv_regnum;

--- a/bbs/wuser.h
+++ b/bbs/wuser.h
@@ -771,20 +771,20 @@ class WUser {
   const unsigned long GetRegisteredDateNum() const {
     return data.registered;
   }
-  void SetRegisteredDateNum(unsigned long l)    {
-    data.registered = l;
+  void SetRegisteredDateNum(time_t l)    {
+    data.registered = static_cast<uint32_t>(l);
   }
-  const unsigned long GetExpiresDateNum() const   {
+  const uint32_t GetExpiresDateNum() const   {
     return data.expires;
   }
-  void SetExpiresDateNum(unsigned long l)       {
-    data.expires = l;
+  void SetExpiresDateNum(time_t l)       {
+    data.expires = static_cast<uint32_t>(l);
   }
   const unsigned long GetNewScanDateNumber() const {
     return data.datenscan;
   }
-  void SetNewScanDateNumber(unsigned long l)    {
-    data.datenscan = l;
+  void SetNewScanDateNumber(time_t l)    {
+    data.datenscan = static_cast<uint32_t>(l);
   }
 
   const float GetTimeOnToday() const      {

--- a/bbs/wwiv_windows.h
+++ b/bbs/wwiv_windows.h
@@ -1,7 +1,7 @@
 /**************************************************************************/
 /*                                                                        */
 /*                              WWIV Version 5.0x                         */
-/*             Copyright (C)1998-2015, WWIV Software Services             */
+/*             Copyright (C)1998-2015,WWIV Software Services             */
 /*                                                                        */
 /*    Licensed  under the  Apache License, Version  2.0 (the "License");  */
 /*    you may not use this  file  except in compliance with the License.  */
@@ -16,50 +16,58 @@
 /*    language governing permissions and limitations under the License.   */
 /*                                                                        */
 /**************************************************************************/
-// Always declare wwiv_windows.h first to avoid collisions on defines.
-#include "bbs/wwiv_windows.h"
+#ifndef __INCLUDED_BBS_WWIV_WINDOWS_H__
+#define __INCLUDED_BBS_WWIV_WINDOWS_H__
 
-#include "bbs/wcomm.h"
+// Wrapper header file for includibng windows.h from wwiv.  This sets all of
+// the numerous #defines to remove much of the windows header files since the
+// surface area used by wwiv is tiny.
 
-#include "core/wwivport.h"
+#ifdef _WIN32
+#define NOGDICAPMASKS
+#define NOSYSMETRICS
+#define NOMENUS
+#define NOICONS
+#define NOKEYSTATES
+#define NOSYSCOMMANDS
+#define NORASTEROPS
+#define NOATOM
+#define NOCLIPBOARD
+#define NODRAWTEXT
+#define NOKERNEL
+#define NONLS
+#define NOMEMMGR
+#define NOMETAFILE
+#define NOMINMAX
+#define NOOPENFILE
+#define NOSCROLL
+#define NOSERVICE
+#define NOSOUND
+#define NOTEXTMETRIC
+#define NOWH
+#define NOCOMM
+#define NOKANJI
+#define NOHELP
+#define NOPROFILER
+#define NODEFERWINDOWPOS
+#define NOMCX
+#define NOCRYPT
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRALEAN
+#include <windows.h>
 
-#if defined ( _WIN32 )
-#include "platform/win32/wiot.h"
-#elif defined ( __unix__ )
-#include "bbs/platform/unix/wiou.h"
-#endif
+#ifdef min
+#undef min
+#endif  // min
 
-#include "core/scope_exit.h"
-#include "core/wwivport.h"
+#ifdef max
+#undef max
+#endif  // max
 
-// static
-std::string WComm::error_text_;
+#ifdef CopyFile
+#undef CopyFile
+#endif  // CopyFile
 
-const std::string WComm::GetLastErrorText() {
-#if defined ( _WIN32 )
-  char* error_text;
-  wwiv::core::ScopeExit on_exit([&error_text] {LocalFree(error_text);});
-  
-  FormatMessage(
-    FORMAT_MESSAGE_ALLOCATE_BUFFER |
-    FORMAT_MESSAGE_FROM_SYSTEM |
-    FORMAT_MESSAGE_IGNORE_INSERTS,
-    nullptr,
-    GetLastError(),
-    MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), // Default language
-    (LPTSTR) &error_text,
-    0,
-    nullptr
-  );
-  error_text_.assign(error_text);
-#endif
-  return error_text_;
-}
+#endif // _WIN32
 
-WComm* WComm::CreateComm(unsigned int nHandle) {
-#if defined ( _WIN32 )
-  return new WIOTelnet(nHandle);
-#elif defined ( __unix__ )
-  return new WIOUnix();
-#endif
-}
+#endif  // __INCLUDED_BBS_WWIV_WINDOWS_H__

--- a/bbs/xfer.cpp
+++ b/bbs/xfer.cpp
@@ -357,19 +357,22 @@ void dliscan_hash(int nDirectoryNum) {
       syscfg.datadir, directories[nDirectoryNum].filename);
   File file(dir);
   if (!file.Open(File::modeBinary | File::modeReadOnly)) {
-    time((time_t *) & (session()->m_DirectoryDateCache[nDirectoryNum]));
+    time_t now = time(nullptr);
+    session()->m_DirectoryDateCache[nDirectoryNum] = static_cast<uint32_t>(now);
     return;
   }
   int nNumRecords = file.GetLength() / sizeof(uploadsrec);
   if (nNumRecords < 1) {
-    time((time_t *) & (session()->m_DirectoryDateCache[nDirectoryNum]));
+    time_t now = time(nullptr);
+    session()->m_DirectoryDateCache[nDirectoryNum] = static_cast<uint32_t>(now);
   } else {
     FileAreaSetRecord(file, 0);
     file.Read(&u, sizeof(uploadsrec));
     if (IsEquals(u.filename, "|MARKER|")) {
       session()->m_DirectoryDateCache[nDirectoryNum] = u.daten;
     } else {
-      time((time_t *) & (session()->m_DirectoryDateCache[nDirectoryNum]));
+      time_t now = time(nullptr);
+      session()->m_DirectoryDateCache[nDirectoryNum] = static_cast<uint32_t>(now);
     }
   }
   file.Close();

--- a/bbs/xfer.cpp
+++ b/bbs/xfer.cpp
@@ -38,7 +38,7 @@ using namespace wwiv::strings;
 static const int INDENTION = 24;
 
 int foundany;
-int this_date;
+uint32_t this_date;
 
 static int ed_num, ed_got;
 static ext_desc_rec *ed_info;

--- a/bbs/xinit.cpp
+++ b/bbs/xinit.cpp
@@ -1125,8 +1125,6 @@ void WApplication::InitializeBBS() {
   set_environment_variable("PKNOFASTCHAR", "Y");
   set_environment_variable("BBS", wwiv_version);
 
-  // TODO: this is empty now.  See if we really need this.
-  //putenv(networkNumEnvVar.c_str());
 #endif // defined ( __unix__ )
 
   XINIT_PRINTF("Reading Voting Booth Configuration.");
@@ -1172,7 +1170,7 @@ void WApplication::InitializeBBS() {
       network_extension = StringPrintf(".%3.3d", nTempInstanceNumber);
       // Fix... Set the global instance variable to match this.  When you run WWIV with the -n<instance> parameter
       // it sets the WWIV_INSTANCE environment variable, however it wasn't doing the reverse.
-      instance_number = nTempInstanceNumber;
+      instance_number_ = nTempInstanceNumber;
     }
   }
 

--- a/bbs/xinit.cpp
+++ b/bbs/xinit.cpp
@@ -1200,7 +1200,7 @@ void WApplication::InitializeBBS() {
     File::Remove(WWIV_NET_DAT);
   }
 
-  srand(time(nullptr));
+  srand(static_cast<unsigned int>(time(nullptr)));
   catsl();
 
   XINIT_PRINTF("Saving Instance information.");

--- a/bbs/xinit.cpp
+++ b/bbs/xinit.cpp
@@ -123,7 +123,7 @@ unsigned char WApplication::stryn2tf(const char *s) {
 
 // end callback addition
 
-#define OFFOF(x) ( reinterpret_cast<long>( &session()->user()->data.x ) - reinterpret_cast<long>( &session()->user()->data ) )
+#define OFFOF(x) static_cast<int16_t>(reinterpret_cast<long>(&session()->user()->data.x) - reinterpret_cast<long>(&session()->user()->data))
 
 // Reads WWIV.INI info from [WWIV] subsection, overrides some config.dat
 // settings (as appropriate), updates config.dat with those values. Also

--- a/bbs_test/bbs_test.vcxproj
+++ b/bbs_test/bbs_test.vcxproj
@@ -53,7 +53,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_USE_32BIT_TIME_T;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
@@ -70,7 +70,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_USE_32BIT_TIME_T;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/core/core.vcxproj
+++ b/core/core.vcxproj
@@ -54,7 +54,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;_CRT_NONSTDC_NO_DEPRECATE;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
       <EnablePREfast>false</EnablePREfast>
@@ -71,7 +71,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;_CRT_NONSTDC_NO_DEPRECATE;WIN32;NOT_BBS;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;WIN32;NOT_BBS;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
       <EnablePREfast>false</EnablePREfast>

--- a/core/file.cpp
+++ b/core/file.cpp
@@ -17,6 +17,12 @@
 /*                                                                        */
 /**************************************************************************/
 #include "core/file.h"
+#ifdef _WIN32
+// Always declare wwiv_windows.h first to avoid collisions on defines.
+#include "bbs/wwiv_windows.h"
+
+#include "Shlwapi.h"
+#endif  // _WIN32
 
 #include <algorithm>
 #include <cerrno>
@@ -34,12 +40,6 @@
 #ifndef _WIN32
 #include <sys/file.h>
 #include <unistd.h>
-#endif  // _WIN32
-
-#ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include "Shlwapi.h"
 #endif  // _WIN32
 
 #include "core/wfndfile.h"

--- a/core/file_win32.cpp
+++ b/core/file_win32.cpp
@@ -17,6 +17,8 @@
 /*                                                                        */
 /**************************************************************************/
 #include "core/file.h"
+// Always declare wwiv_windows.h first to avoid collisions on defines.
+#include "bbs/wwiv_windows.h"
 
 #include <cerrno>
 #include <cstdint>
@@ -28,9 +30,6 @@
 #include <sstream>
 #include <string>
 #include <sys/stat.h>
-
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
 
 #include "core/wfndfile.h"
 #include "core/wwivassert.h"

--- a/core/textfile.cpp
+++ b/core/textfile.cpp
@@ -17,6 +17,8 @@
 /*                                                                        */
 /**************************************************************************/
 #include "core/textfile.h"
+// Always declare wwiv_windows.h first to avoid collisions on defines.
+#include "bbs/wwiv_windows.h"
 
 #include <iostream>
 #include <cerrno>
@@ -33,8 +35,6 @@
 #ifdef _WIN32
 #include <io.h>
 #include <share.h>
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
 
 #else  // _WIN32
 #include <sys/file.h>

--- a/core/wfndfile.h
+++ b/core/wfndfile.h
@@ -22,14 +22,9 @@
 
 #include <cstring>
 #include <string>
+#include "bbs/wwiv_windows.h"
 #include "core/wwivport.h"
 
-#if defined( _WIN32 )
-#define VC_EXTRALEAN
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#undef CopyFile
-#endif // _WIN32
 
 class WFindFile {
  protected:

--- a/core_test/core_fixtures.vcxproj
+++ b/core_test/core_fixtures.vcxproj
@@ -53,7 +53,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
@@ -70,7 +70,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/core_test/core_test.vcxproj
+++ b/core_test/core_test.vcxproj
@@ -53,7 +53,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_USE_32BIT_TIME_T;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <ExceptionHandling>Async</ExceptionHandling>
@@ -72,7 +72,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/fix/fix.vcxproj
+++ b/fix/fix.vcxproj
@@ -50,7 +50,7 @@
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>NOT_BBS;FIX;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_USE_32BIT_TIME_T;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NOT_BBS;FIX;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>
       </AdditionalIncludeDirectories>
@@ -67,7 +67,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NOT_BBS;FIX;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_USE_32BIT_TIME_T;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NOT_BBS;FIX;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>
       </AdditionalIncludeDirectories>

--- a/init/init.vcxproj
+++ b/init/init.vcxproj
@@ -52,7 +52,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;_CRT_NONSTDC_NO_DEPRECATE;WIN32;NOT_BBS;INIT;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;WIN32;NOT_BBS;INIT;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
     </ClCompile>
@@ -68,7 +68,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;_CRT_NONSTDC_NO_DEPRECATE;WIN32;NOT_BBS;INIT;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;WIN32;NOT_BBS;INIT;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
     </ClCompile>

--- a/initlib/curses_io.cpp
+++ b/initlib/curses_io.cpp
@@ -16,6 +16,8 @@
 /*    language governing permissions and limitations under the License.   */
 /*                                                                        */
 /**************************************************************************/
+// Always declare wwiv_windows.h first to avoid collisions on defines.
+#include "bbs/wwiv_windows.h"
 
 #include <algorithm>
 #include <cstring>
@@ -26,14 +28,9 @@
 #include <stdexcept>
 
 #include "curses.h"
-#include "curses_io.h"
 #include "core/strings.h"
 #include "core/version.h"
-
-#ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#endif  // _WIN32
+#include "initlib/curses_io.h"
 
 using std::unique_ptr;
 using std::string;

--- a/initlib/initlib.vcxproj
+++ b/initlib/initlib.vcxproj
@@ -52,7 +52,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;_CRT_NONSTDC_NO_DEPRECATE;WIN32;NOT_BBS;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;WIN32;NOT_BBS;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
     </ClCompile>
@@ -68,7 +68,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;_CRT_NONSTDC_NO_DEPRECATE;WIN32;NOT_BBS;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;WIN32;NOT_BBS;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
     </ClCompile>

--- a/network/network.vcxproj
+++ b/network/network.vcxproj
@@ -53,7 +53,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_USE_32BIT_TIME_T;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
     </ClCompile>
@@ -70,7 +70,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;_USE_32BIT_TIME_T;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
     </ClCompile>

--- a/networkb/networkb.vcxproj
+++ b/networkb/networkb.vcxproj
@@ -53,7 +53,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_USE_32BIT_TIME_T;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
     </ClCompile>
@@ -70,7 +70,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;_USE_32BIT_TIME_T;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
     </ClCompile>

--- a/networkb/networkb_lib.vcxproj
+++ b/networkb/networkb_lib.vcxproj
@@ -53,7 +53,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_USE_32BIT_TIME_T;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
     </ClCompile>
@@ -70,7 +70,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;_USE_32BIT_TIME_T;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
     </ClCompile>

--- a/networkb_test/fake_connection.cpp
+++ b/networkb_test/fake_connection.cpp
@@ -138,7 +138,7 @@ void FakeConnection::ReplyCommand(int8_t command_id, const string& data) {
   unique_ptr<char[]> packet(new char[size]);
   // Actual packet size parameter does not include the size parameter itself.
   // And for sending a commmand this will be 2 less than our actual packet size.
-  uint16_t packet_length = (data.size() + sizeof(uint8_t)) | 0x8000;
+  uint16_t packet_length = static_cast<uint16_t>(data.size() + sizeof(uint8_t)) | 0x8000;
   uint8_t b0 = ((packet_length & 0xff00) >> 8) | 0x80;
   uint8_t b1 = packet_length & 0x00ff;
 

--- a/networkb_test/networkb_test.vcxproj
+++ b/networkb_test/networkb_test.vcxproj
@@ -53,7 +53,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;_CRT_NONSTDC_NO_DEPRECATE;_USE_32BIT_TIME_T;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <ExceptionHandling>Async</ExceptionHandling>
@@ -72,7 +72,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/sdk/sdk.vcxproj
+++ b/sdk/sdk.vcxproj
@@ -65,7 +65,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;_CRT_NONSTDC_NO_DEPRECATE;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
     </ClCompile>
@@ -81,7 +81,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;_CRT_NONSTDC_NO_DEPRECATE;WIN32;NOT_BBS;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;WIN32;NOT_BBS;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
     </ClCompile>

--- a/sdk_test/sdk_test.vcxproj
+++ b/sdk_test/sdk_test.vcxproj
@@ -53,7 +53,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_USE_32BIT_TIME_T;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <ExceptionHandling>Async</ExceptionHandling>
@@ -72,7 +72,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
Use 64-bit time_t on Windows like we do on UNIX (big source of problems)
Also removed about 1/3 of the new warnings from compiling with MSVC2015.  Lots more to go, but this is a start.
