### PR TITLE
Fix networkb not receiving files since it was munging packets

### DIFF
--- a/networkb/binkp.cpp
+++ b/networkb/binkp.cpp
@@ -206,6 +206,9 @@ bool BinkP::process_data(int16_t length, milliseconds d) {
     received_files_.push_back(current_receive_file_->filename());
     current_receive_file_.release();
     send_command_packet(BinkpCommands::M_GOT, data_line);
+  } else {
+    LOG << "       file still transferring; bytes_received: " << current_receive_file_->length()
+        << " and: " << current_receive_file_->expected_length() << " bytes expected.";
   }
 
   return true;
@@ -229,13 +232,16 @@ bool BinkP::process_frames(std::function<bool()> predicate, milliseconds d) {
         }
       } else {
         // process data frame.
-        if (!process_data(header & 0x7fff, d)) {
+        // note: always use a timeout of 10s to process data since dropping bytes
+        // causes real problems.
+        if (!process_data(header & 0x7fff, seconds(10))) {
           // false return value mean san error occurred.
           return false;
         }
       }
     }
-  } catch (timeout_error&) {
+  } catch (timeout_error& e) {
+    LOG << e.what();
   }
   return true;
 }
@@ -482,15 +488,17 @@ BinkState BinkP::TransferFiles() {
 
   LOG << "STATE: TransferFiles to node: " << remote_node;
   // Quickly let the inbound event loop percolate.
-  process_frames(milliseconds(100));
+  process_frames(milliseconds(500));
   SendFiles file_sender(config_->network_dir(network_name), remote_node);
   const auto list = file_sender.CreateTransferFileList();
   for (auto file : list) {
     SendFilePacket(file);
   }
+
+  LOG << "STATE: After SendFilePacket for all files.";
   // Quickly let the inbound event loop percolate.
   for (int i=0; i < 5; i++) {
-    process_frames(milliseconds(50));
+    process_frames(milliseconds(500));
   }
 
   // TODO(rushfan): Should this be in a new state?
@@ -501,6 +509,8 @@ BinkState BinkP::TransferFiles() {
     // it send (yes, even with TCP_NODELAY set).
     send_command_packet(BinkpCommands::M_EOB, "All files to send have been sent. Thank you.");
     process_frames(seconds(1));
+  } else {
+    LOG << "       files_to_send_ is not empty, Not sending EOB";
   }
   return BinkState::WAIT_EOB;
 }
@@ -555,7 +565,7 @@ bool BinkP::SendFilePacket(TransferFile* file) {
 }
 
 bool BinkP::SendFileData(TransferFile* file) {
-  LOG << "       SendFilePacket: " << file->filename();
+  LOG << "       SendFileData: " << file->filename();
   long file_length = file->file_size();
   const int chunk_size = 16384; // This is 1<<14.  The max per spec is (1 << 15) - 1
   long start = 0;

--- a/networkb/binkp.cpp
+++ b/networkb/binkp.cpp
@@ -241,7 +241,6 @@ bool BinkP::process_frames(std::function<bool()> predicate, milliseconds d) {
       }
     }
   } catch (timeout_error& e) {
-    LOG << e.what();
   }
   return true;
 }

--- a/networkb/binkp.cpp
+++ b/networkb/binkp.cpp
@@ -188,7 +188,7 @@ bool BinkP::process_data(int16_t length, milliseconds d) {
   unique_ptr<char[]> data(new char[length]);
   int length_received = conn_->receive(data.get(), length, d);
   string s(data.get(), length);
-  LOG << "RECV:  DATA PACKET; len: " << length_received;
+  LOG << "RECV:  DATA PACKET; len: " << length_received << "; expected: " << length << " duration:" << d.count();
   if (!current_receive_file_) {
     LOG << "ERROR: Received M_DATA with no current file.";
     return false;

--- a/networkb/socket_connection.cpp
+++ b/networkb/socket_connection.cpp
@@ -233,7 +233,7 @@ static int read_TYPE(const SOCKET sock, TYPE* data, const milliseconds d, std::s
       }
     }
     if (result == 0) {
-      return 0;
+      return total_read;
     }
     total_read += result;
     if (total_read < size) {
@@ -241,9 +241,9 @@ static int read_TYPE(const SOCKET sock, TYPE* data, const milliseconds d, std::s
       remaining -= result;
       continue;
     }
-    return result;
+    return total_read;
   }
-  throw socket_error("unknown error reading from socket");
+  throw socket_error("unknown error reading from socket.");
 }
 
 int SocketConnection::receive(void* data, const int size, milliseconds d) {


### PR DESCRIPTION
If a binkp packet arrived in >1 network packet, the receive call was keeping the packet size from the last packet (S) but keeping the 1st 1..S bytes from the 1st packet.
