### PR TITLE
Fix https://github.com/wwivbbs/wwiv/issues/168

### DIFF
--- a/bbs/lilo.cpp
+++ b/bbs/lilo.cpp
@@ -1101,6 +1101,7 @@ void logoff() {
 
 
 void logon_guest() {
+  session()->SetUserOnline(true);
   bout.nl(2);
   input_ansistat();
 

--- a/bbs/pause.cpp
+++ b/bbs/pause.cpp
@@ -50,7 +50,7 @@ TempDisablePause::TempDisablePause() : wwiv::core::Transaction([] {
 
 static char GetKeyForPause() {
   char ch = 0;
-  while (ch == 0) {
+  while (ch == 0 && !hangup) {
     ch = bgetch();
     sleep_for(milliseconds(50));
     CheckForHangup();


### PR DESCRIPTION
two problems:
1) pause could hang on disconnect, this isn't
related to guest login.
2) guest login wasn't setting useron, so the bbs wouldn't
exit on hangup.
