### PR TITLE
explicitly set length_ to zero, I have a hypothesis that on xenos's

### DIFF
--- a/networkb/receive_file.h
+++ b/networkb/receive_file.h
@@ -30,7 +30,7 @@ namespace net {
 class  ReceiveFile {
  public:
  	ReceiveFile(TransferFile* file, const std::string& filename, long expected_length, time_t timestamp)
-      : file_(file), filename_(filename), expected_length_(expected_length), timestamp_(timestamp) {}
+      : file_(file), filename_(filename), expected_length_(expected_length), timestamp_(timestamp), length_(0) {}
  	~ReceiveFile() {}
 
   bool WriteChunk (const char* chunk, size_t size) { 


### PR DESCRIPTION
compile it's not being set to zero and is causing the count of
bytes received to be off.
Example from his log:
I20151105:171357        file still transferring; bytes_received:
 -1217731504 and: 2215 bytes expected.
