### PR TITLE
start counting args at 1 and not 0.  On windows it didn't matter since

### DIFF
--- a/network/network.cpp
+++ b/network/network.cpp
@@ -57,7 +57,7 @@ static void ShowHelp() {
 
 static map<string, string> ParseArgs(int argc, char** argv) {
   map<string, string> args;
-  for (int i = 0; i < argc; i++) {
+  for (int i = 1; i < argc; i++) {
     const string s(argv[i]);
     if (starts_with(s, "--")) {
       const vector<string> delims = SplitString(s, "=");


### PR DESCRIPTION
argv[0] never started with /. but on UNIX it does and was being processed
as an argument.
Fixed https://github.com/wwivbbs/wwiv/issues/314
