### PR TITLE
Convert from *abs() to std::abs().

### DIFF
--- a/bbs/batch.cpp
+++ b/bbs/batch.cpp
@@ -844,7 +844,7 @@ void bihangup(int up) {
   do {
     while (!bkbhit() && !hangup) {
       long dd = timer1();
-      if (abs(dd - timelastchar1) > 65536L) {
+      if (std::abs(dd - timelastchar1) > 65536L) {
         nextbeep -= 1572480L;
         timelastchar1 -= 1572480L;
       }
@@ -859,7 +859,7 @@ void bihangup(int up) {
           color = 6;
         }
       }
-      if (abs(dd - timelastchar1) > 182L) {
+      if (std::abs(dd - timelastchar1) > 182L) {
         bout.nl();
         bout << "Thank you for calling.";
         bout.nl();

--- a/bbs/bbs.cpp
+++ b/bbs/bbs.cpp
@@ -526,7 +526,7 @@ int WApplication::doWFCEvents() {
           session()->SetFileAreaCacheNumber(session()->GetFileAreaCacheNumber() + 1);
         } else {
           static int mult_time = 0;
-          if (this->IsCleanNetNeeded() || abs(timer1() - mult_time) > 1000L) {
+          if (this->IsCleanNetNeeded() || std::abs(timer1() - mult_time) > 1000L) {
             cleanup_net();
             mult_time = timer1();
             giveup_timeslice();
@@ -546,7 +546,7 @@ int WApplication::LocalLogon() {
   bout << "|#9Log on to the BBS?";
   double d = timer();
   int lokb = 0;
-  while (!session()->localIO()->LocalKeyPressed() && (fabs(timer() - d) < SECONDS_PER_MINUTE_FLOAT))
+  while (!session()->localIO()->LocalKeyPressed() && (std::abs(timer() - d) < SECONDS_PER_MINUTE_FLOAT))
     ;
 
   if (session()->localIO()->LocalKeyPressed()) {
@@ -984,7 +984,7 @@ int WApplication::Run(int argc, char *argv[]) {
       double dt = timer();
       session()->localIO()->LocalCls();
       bout << "\r\n>> SYSOP ALERT ACTIVATED <<\r\n\n";
-      while (!session()->localIO()->LocalKeyPressed() && (fabs(timer() - dt) < SECONDS_PER_MINUTE_FLOAT)) {
+      while (!session()->localIO()->LocalKeyPressed() && (std::abs(timer() - dt) < SECONDS_PER_MINUTE_FLOAT)) {
         sound(500, milliseconds(250));
         sleep_for(milliseconds(1));
       }

--- a/bbs/colors.cpp
+++ b/bbs/colors.cpp
@@ -161,7 +161,7 @@ void color_config() {
       if (yesno()) {
         bout << "\r\nColor saved.\r\n\n";
         if ((n <= -1) && (n >= -16)) {
-          rescolor.resx[207 + abs(n)] = static_cast< unsigned char >(c);
+          rescolor.resx[207 + std::abs(n)] = static_cast< unsigned char >(c);
         } else if ((n >= 0) && (n <= 9)) {
           session()->user()->SetColor(n, c);
         } else {

--- a/bbs/com.cpp
+++ b/bbs/com.cpp
@@ -149,7 +149,7 @@ char getkey() {
       if (dd < timelastchar1 && ((dd + 1000) > timelastchar1)) {
         timelastchar1 = dd;
       }
-      if (abs(dd - timelastchar1) > 65536L) {
+      if (std::abs(dd - timelastchar1) > 65536L) {
         timelastchar1 -= static_cast<int>(floor(SECONDS_PER_DAY * 18.2));
       }
       if ((dd - timelastchar1) > tv1 && !beepyet) {
@@ -157,7 +157,7 @@ char getkey() {
         bputch(CG);
       }
       application()->UpdateShutDownStatus();
-      if (abs(dd - timelastchar1) > tv) {
+      if (std::abs(dd - timelastchar1) > tv) {
         bout.nl();
         bout << "Call back later when you are there.\r\n";
         hangup = true;

--- a/bbs/instmsg.cpp
+++ b/bbs/instmsg.cpp
@@ -594,7 +594,7 @@ bool inst_msg_waiting() {
   }
 
   long l = timer1();
-  if (abs(l - last_iia) < iia) {
+  if (std::abs(l - last_iia) < iia) {
     return false;
   }
 

--- a/bbs/listplus.cpp
+++ b/bbs/listplus.cpp
@@ -649,7 +649,7 @@ int print_extended_plus(const char *pszFileName, int numlist, int indent, int co
   int cpos = 0;
   int chars_this_line = 0;
 
-  int will_fit = 80 - abs(indent) - 2;
+  int will_fit = 80 - std::abs(indent) - 2;
 
   char * ss = read_extended_description(pszFileName);
 
@@ -679,7 +679,7 @@ int print_extended_plus(const char *pszFileName, int numlist, int indent, int co
         if (ch == SOFTRETURN && indent) {
           bout.SystemColor(color);
           bputch('\r');
-          bout << "\x1b[" << abs(indent) << "C";
+          bout << "\x1b[" << std::abs(indent) << "C";
         }
         do {
           ch = new_ss[cpos++];

--- a/bbs/netsup.cpp
+++ b/bbs/netsup.cpp
@@ -464,7 +464,7 @@ void attempt_callout() {
   if (last_time_c > tCurrentTime) {
     last_time_c = 0L;
   }
-  if (abs(last_time_c - tCurrentTime) < 120) {
+  if (std::abs(last_time_c - tCurrentTime) < 120) {
     return;
   }
   if (last_time_c == 0L) {
@@ -534,14 +534,14 @@ void attempt_callout() {
           }
         }
         if (con[i].options & options_once_per_day) {
-          if (abs(tCurrentTime - ncn[i2].lastcontactsent) <
+          if (std::abs(tCurrentTime - ncn[i2].lastcontactsent) <
               (20L * SECONDS_PER_HOUR / con[i].times_per_day)) {
             ok = false;
           }
         }
         if (ok) {
           if ((bytes_to_k(ncn[i2].bytes_waiting) < con[i].min_k)
-              && (abs(tCurrentTime - ncn[i2].lastcontact) < SECONDS_PER_DAY)) {
+              && (std::abs(tCurrentTime - ncn[i2].lastcontact) < SECONDS_PER_DAY)) {
             ok = false;
           }
         }

--- a/bbs/sr.cpp
+++ b/bbs/sr.cpp
@@ -52,7 +52,7 @@ char gettimeout(double d, bool *abort) {
   }
 
   double d1 = timer();
-  while (fabs(timer() - d1) < d && !bkbhitraw() && !hangup && !*abort) {
+  while (std::abs(timer() - d1) < d && !bkbhitraw() && !hangup && !*abort) {
     if (session()->localIO()->LocalKeyPressed()) {
       char ch = session()->localIO()->LocalGetChar();
       if (ch == 0) {

--- a/bbs/srrcv.cpp
+++ b/bbs/srrcv.cpp
@@ -46,7 +46,7 @@ char modemkey(int *tout) {
     return 0;
   }
   double d1 = timer();
-  while (fabs(timer() - d1) < 0.5 && !bkbhitraw() && !hangup) {
+  while (std::abs(timer() - d1) < 0.5 && !bkbhitraw() && !hangup) {
     CheckForHangup();
   }
   if (bkbhitraw()) {
@@ -201,7 +201,7 @@ void xymodem_receive(const char *pszFileName, bool *received, bool bUseCRC) {
     }
 
     double d1 = timer();
-    while (fabs(timer() - d1) < 10.0 && !bkbhitraw() && !hangup) {
+    while (std::abs(timer() - d1) < 10.0 && !bkbhitraw() && !hangup) {
       CheckForHangup();
       if (session()->localIO()->LocalKeyPressed()) {
         ch = session()->localIO()->LocalGetChar();

--- a/bbs/srsend.cpp
+++ b/bbs/srsend.cpp
@@ -154,7 +154,7 @@ bool okstart(bool *bUseCRC, bool *abort) {
   bool   ok   = false;
   bool   done = false;
 
-  while (fabs(timer() - d) < 90.0 && !done && !hangup && !*abort) {
+  while (std::abs(timer() - d) < 90.0 && !done && !hangup && !*abort) {
     char ch = gettimeout(91.0 - d, abort);
     if (ch == 'C') {
       *bUseCRC = true;

--- a/bbs/utility.cpp
+++ b/bbs/utility.cpp
@@ -210,7 +210,7 @@ void Wait(double d) {
   }
   const long lStartTime = timer1();
   auto l = d * 18.2;
-  while (abs(timer1() - lStartTime) < l) {
+  while (std::abs(timer1() - lStartTime) < l) {
     giveup_timeslice();
   }
 }

--- a/bbs/wfc.cpp
+++ b/bbs/wfc.cpp
@@ -191,7 +191,7 @@ static void CleanNetIfNeeded() {
       session()->SetFileAreaCacheNumber(session()->GetFileAreaCacheNumber() + 1);
     } else {
       static int mult_time = 0;
-      if (application()->IsCleanNetNeeded() || abs(timer1() - mult_time) > 1000L) {
+      if (application()->IsCleanNetNeeded() || std::abs(timer1() - mult_time) > 1000L) {
         cleanup_net();
         mult_time = timer1();
       }

--- a/bbs/woutstream.cpp
+++ b/bbs/woutstream.cpp
@@ -61,7 +61,7 @@ void WOutStream::Color(int wwivColor) {
 
   if (wwivColor <= -1 && wwivColor >= -16) {
     c = (session()->user()->HasColor() ?
-         rescolor.resx[207 + abs(wwivColor)] : session()->user()->GetBWColor(0));
+         rescolor.resx[207 + std::abs(wwivColor)] : session()->user()->GetBWColor(0));
   }
   if (wwivColor >= 0 && wwivColor <= 9) {
     c = (session()->user()->HasColor() ?


### PR DESCRIPTION
Fixes various warnings of parameter types and truncation.
