### PR TITLE
Swipe OS name strings from Synchronet

### DIFF
--- a/core/os_unix.cpp
+++ b/core/os_unix.cpp
@@ -64,9 +64,39 @@ std::string os_version_string() {
   return std::string("Linux");
 #elif defined ( __APPLE__ )
   return string(""); // StringPrintf("%s %s", GetOSNameString(), GetMacVersionString());
-#elif defined ( __unix__ )
+#elif defined(_WIN64)
+  return string("Win64");
+#elif defined(_WIN32)
+  return string("Win32");
+#elif defined(__OS2__)
+  return string("OS/2");
+#elif defined(__MSDOS__)
+  return string("DOS");
+#elif defined(__linux__)
+  return string("Linux");
+#elif defined(__FreeBSD__)
+  return string("FreeBSD");
+#elif defined(__OpenBSD__)
+  return string("OpenBSD");
+#elif defined(__NetBSD__)
+  return string("NetBSD");
+#elif defined(__APPLE__) && defined(__MACH__) && defined(__POWERPC__)
+  return string("MacOSX");
+#elif defined(BSD)
+  return string("BSD");
+#elif defined(__solaris__)
+  return string("Solaris");
+#elif defined(__sun__)
+  return string("SunOS");
+#elif defined(__gnu__)
+  return string("GNU/Hurd");
+#elif defined(__QNX__)
+  return string("QNX");
+#elif defined(__unix__)
   // TODO Add Linux version information code here..
   return string("UNIX");
+#elif defined(__HAIKU__)
+  return string("Haiku");
 #endif
   return string("UNKNOWN OS");
 }


### PR DESCRIPTION
Add a bunch of (mostly unsupported) OS names.  List came from
Synchronet's xpdev/genwrap.h.

This was mostly to just get FreeBSD to say it's FreeBSD.  :-)
