### PR TITLE
Cleanup the multiple things hacked into the message title field

### DIFF
--- a/bbs/admin/readme.510
+++ b/bbs/admin/readme.510
@@ -1,26 +1,24 @@
-readme.500
+readme.510
 09/10/2014
 
                 *** Attention Windows 10 ***
 
-    You need to download the Visual Studio 2015 RC redistributable files from:
-    https://www.microsoft.com/en-us/download/details.aspx?id=46881
+    You need to download the Visual Studio 2015 redistributable files from:
+    https://www.microsoft.com/en-us/download/details.aspx?id=48145
     and install this package before using WWIV (or any other software
-    compiled with Visual Studio 2015 RC).
+    compiled with Visual Studio 2015).
 
 
-WWIV 5.0 Getting Started
+WWIV 5.1 Getting Started
 ~~~~~~~~~~~~~~~~~~~~~~~~
-If you already have WWIV 5.0 installed, just copy the EXE and DLL files over
-your existing 4.30 installation. Please backup your previous binaries and
-configuration files.
+If you already have WWIV 4.3 or 5.0 installed, just copy the EXE and DLL 
+files over your existing 4.3/5.0 installation. Please backup your previous binaries and configuration files.
 
 The command line parameters have changed quite a bit, I suggest running
-"WWIV50 -? | MORE" to see the list of changes.  Currently WWIV50 is command
-line compatable with EleBBS (for all of the major command line arguments)
+"bbs -? | more" to see the list of changes.
 
-So far, WWIV 5.0 is still fully compatable with your existing WWIV 4.30
-installation (Just drop it in and go).
+So far, WWIV 5.1 is still fully compatable with your existing WWIV 4.30
+and 5.0 installations (Just drop it in and go).
 
 Run WWIV5TelnetServer.exe and then select the menu Edit > Preferences and setup
 the information for your configuration (paths, and the starting and ending
@@ -30,7 +28,7 @@ instances of WWIV.  You do not need to keep multiple copies of WWIV running
 at all times, as the WTS will spawn them as required.
 
 *** Be sure to read WHATSNEW.TXT for a list of all the new major features and
-other changes that have happened since 4.30. ***
+other changes that have happened since 5.0. ***
 
 NOTE: Serial I/O Support has been removed. Use one of the serial -> telnet
 bridges for "Dial Up" support.
@@ -39,11 +37,11 @@ DEVELOPMENT INFORMATION
 ~~~~~~~~~~~~~~~~~~~~~~~
 
     WWIV is compiled with the following compilers:
-        MS Visual C++ 2013.
-        GCC 4.8 on Linux
+        MS Visual C++ 2015 Community Edition.
+        GCC 4.9 on Linux
 
-    I recommend using MSVC 2013. (There is a the "express" edition
-    available for free.
+    I recommend using MSVC 2015 Community Edition on Windows.
+    It is available for free.
 
 
 ===============================================================================

--- a/bbs/admin/whatsnew.txt
+++ b/bbs/admin/whatsnew.txt
@@ -1,10 +1,18 @@
 ==============================================================================
-                           WWIV 5.0 What's New List
-                 Copyright 1999-2014 WWIV Software Services
+                           WWIV 5.1 What's New List
+                 Copyright 1999-2015 WWIV Software Services
 ==============================================================================
 
-What's New in 2015
-~~~~~~~~~~~~~~~~~~
+What's New in WWIV 5.1 (2015)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Message titles are not limited to 72 characters (same as FidoNet message)
+  limits.  In reality they would get truncated around this length anyway and
+  in most places WWIV still forces a max of 60 characters.
+* Internal application-level caching for posts have been removed. It didn't help
+  access times anymore and added lots of unneeded complexity.
+
+What's New in 2015 (WWIV 5.0)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * networkb - BINKP transport for WWIV networking is now part of the WWIV builds.
 * netutil - Network packet and config file utility now included
 * network - shim to proxy between network0, networkp (PPP project) and networkb
@@ -21,8 +29,8 @@ What's New in 2015
 
 
 
-What's New in 2014
-~~~~~~~~~~~~~~~~~~
+What's New in 2014 (WWIV 5.0)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Many more things work.
 * Init is open sourced
 * Full self-bootstrapping support. No longer need 4.30 installed first.
@@ -68,8 +76,8 @@ What's New in 2014
   EXEC_CHILDWAITTIME  should be used to set how long to wait for exec'ed
   processes to become runnable. It defaults to 500ms.
 
-What's New in Beta-2
-~~~~~~~~~~~~~~~~~~~~~
+What's New in 5.0 Beta-2
+~~~~~~~~~~~~~~~~~~~~~~~~~
 * Archver commands now work.
 * F1 User Editor Improvements
 * PuTTY now works with auto-detect line mode
@@ -83,8 +91,8 @@ What's New in Beta-2
 * Misc internal code cleanups.
 
 
-What's New in Beta-1
-~~~~~~~~~~~~~~~~~~~~
+What's New in 5.0 Beta-1
+~~~~~~~~~~~~~~~~~~~~~~~~
 * File compatable with 4.30/4.31
 * 32-bit Win32 version.
 * Compiles and Runs on Linux.

--- a/bbs/msgbase.cpp
+++ b/bbs/msgbase.cpp
@@ -464,7 +464,7 @@ void sendout_email(const string& title, messagerec * pMessageRec, int anony, int
     m.status |= status_new_net;
     // always trim to WWIV_MESSAGE_TITLE_LENGTH now.
     m.title[71] = '\0';
-    m.network_number = static_cast<int8_t>(nFromNetworkNumber);
+    m.network_msg.net_number = static_cast<int8_t>(nFromNetworkNumber);
   }
 
   if (nSystemNumber == 0) {
@@ -1259,7 +1259,7 @@ void read_message(int n, bool *next, int *val) {
     int nNetNumSaved = session()->GetNetworkNumber();
 
     if (p.status & status_post_new_net) {
-      set_net_num(p.network_number);
+      set_net_num(p.network_msg.net_number);
     }
     read_message1(&(p.msg), static_cast<char>(p.anony & 0x0f), bReadit, next,
                   (subboards[session()->GetCurrentReadMessageArea()].filename), p.ownersys, p.owneruser);

--- a/bbs/msgbase.cpp
+++ b/bbs/msgbase.cpp
@@ -445,6 +445,7 @@ void sendout_email(const string& title, messagerec * pMessageRec, int anony, int
   net_header_rec nh;
   int i;
 
+  memset(&m, 0, sizeof(mailrec));
   strcpy(m.title, title.c_str());
   m.msg = *pMessageRec;
   m.anony = static_cast< unsigned char >(anony);
@@ -461,8 +462,9 @@ void sendout_email(const string& title, messagerec * pMessageRec, int anony, int
 
   if (m.fromsys && session()->GetMaxNetworkNumber() > 1) {
     m.status |= status_new_net;
-    m.title[79] = '\0';
-    m.title[80] = static_cast<char>(nFromNetworkNumber);
+    // always trim to WWIV_MESSAGE_TITLE_LENGTH now.
+    m.title[71] = '\0';
+    m.network_number = static_cast<int8_t>(nFromNetworkNumber);
   }
 
   if (nSystemNumber == 0) {
@@ -1257,7 +1259,7 @@ void read_message(int n, bool *next, int *val) {
     int nNetNumSaved = session()->GetNetworkNumber();
 
     if (p.status & status_post_new_net) {
-      set_net_num(p.title[80]);
+      set_net_num(p.network_number);
     }
     read_message1(&(p.msg), static_cast<char>(p.anony & 0x0f), bReadit, next,
                   (subboards[session()->GetCurrentReadMessageArea()].filename), p.ownersys, p.owneruser);

--- a/bbs/msgbase1.cpp
+++ b/bbs/msgbase1.cpp
@@ -55,7 +55,7 @@ void send_net_post(postrec* pPostRecord, const char* extra, int nSubNumber) {
   int nNetNumber;
   int nOrigNetNumber = session()->GetNetworkNumber();
   if (pPostRecord->status & status_post_new_net) {
-    nNetNumber = pPostRecord->title[80];
+    nNetNumber = pPostRecord->network_number;
   } else if (xsubs[nSubNumber].num_nets) {
     nNetNumber = xsubs[nSubNumber].nets[0].net_num;
   } else {
@@ -221,6 +221,7 @@ void post() {
   write_inst(INST_LOC_POST, session()->GetCurrentReadMessageArea(), INST_FLAGS_NONE);
 
   postrec p;
+  memset(&p, 0, sizeof(postrec));
   string title;
   inmsg(&m, &title, &a, true, (subboards[session()->GetCurrentReadMessageArea()].filename), INMSG_FSED,
         subboards[session()->GetCurrentReadMessageArea()].name,

--- a/bbs/msgbase1.cpp
+++ b/bbs/msgbase1.cpp
@@ -55,7 +55,7 @@ void send_net_post(postrec* pPostRecord, const char* extra, int nSubNumber) {
   int nNetNumber;
   int nOrigNetNumber = session()->GetNetworkNumber();
   if (pPostRecord->status & status_post_new_net) {
-    nNetNumber = pPostRecord->network_number;
+    nNetNumber = pPostRecord->network_msg.net_number;
   } else if (xsubs[nSubNumber].num_nets) {
     nNetNumber = xsubs[nSubNumber].nets[0].net_num;
   } else {

--- a/bbs/msgscan.cpp
+++ b/bbs/msgscan.cpp
@@ -613,8 +613,8 @@ void HandleScanReadAutoReply(int &nMessageNumber, const char *pszUserInput, int 
   }
 
   if (get_post(nMessageNumber)->status & status_post_new_net) {
-    set_net_num(get_post(nMessageNumber)->network_number);
-    if (get_post(nMessageNumber)->network_number == -1) {
+    set_net_num(get_post(nMessageNumber)->network_msg.net_number);
+    if (get_post(nMessageNumber)->network_msg.net_number == -1) {
       bout << "|#6Deleted network.\r\n";
       return;
     }

--- a/bbs/msgscan.cpp
+++ b/bbs/msgscan.cpp
@@ -613,8 +613,8 @@ void HandleScanReadAutoReply(int &nMessageNumber, const char *pszUserInput, int 
   }
 
   if (get_post(nMessageNumber)->status & status_post_new_net) {
-    set_net_num(get_post(nMessageNumber)->title[80]);
-    if (get_post(nMessageNumber)->title[80] == -1) {
+    set_net_num(get_post(nMessageNumber)->network_number);
+    if (get_post(nMessageNumber)->network_number == -1) {
       bout << "|#6Deleted network.\r\n";
       return;
     }

--- a/bbs/multmail.cpp
+++ b/bbs/multmail.cpp
@@ -43,6 +43,7 @@ void multimail(int *pnUserNumber, int numu) {
   mailrec m, m1;
   char s[255], s2[81];
   WUser user;
+  memset(&m, 0, sizeof(mailrec));
 
   if (freek1(syscfg.msgsdir) < 10) {
     bout.nl();

--- a/bbs/qwk.cpp
+++ b/bbs/qwk.cpp
@@ -357,7 +357,7 @@ void make_pre_qwk(int msgnum, struct qwk_junk *qwk_info) {
 
   int nn = session()->GetNetworkNumber();
   if (p->status & status_post_new_net) {
-    set_net_num(p->title[80]);
+    set_net_num(p->network_number);
   }
 
   put_in_qwk(p, (subboards[session()->GetCurrentReadMessageArea()].filename), msgnum, qwk_info);

--- a/bbs/qwk.cpp
+++ b/bbs/qwk.cpp
@@ -357,7 +357,7 @@ void make_pre_qwk(int msgnum, struct qwk_junk *qwk_info) {
 
   int nn = session()->GetNetworkNumber();
   if (p->status & status_post_new_net) {
-    set_net_num(p->network_number);
+    set_net_num(p->network_msg.net_number);
   }
 
   put_in_qwk(p, (subboards[session()->GetCurrentReadMessageArea()].filename), msgnum, qwk_info);

--- a/bbs/qwk1.cpp
+++ b/bbs/qwk1.cpp
@@ -50,6 +50,7 @@
 #include "core/os.h"
 #include "core/strings.h"
 #include "core/wwivport.h"
+#include "sdk/message_utils_wwiv.h"
 
 using std::chrono::milliseconds;
 using std::string;
@@ -57,6 +58,7 @@ using std::unique_ptr;
 
 using namespace wwiv::os;
 using namespace wwiv::strings;
+using namespace wwiv::sdk::msgapi;
 
 #define SET_BLOCK(file, pos, size) lseek(file, (long)pos * (long)size, SEEK_SET)
 #define qwk_iscan_literal(x) (iscan1(x))
@@ -127,7 +129,7 @@ void qwk_remove_email() {
 
 
 void qwk_gather_email(struct qwk_junk *qwk_info) {
-  int i, mfl, curmail, done, tp, nn;
+  int i, mfl, curmail, done;
   char filename[201];
   mailrec m;
   postrec junk;
@@ -207,20 +209,7 @@ void qwk_gather_email(struct qwk_junk *qwk_info) {
     } else {
       net_email_name[0] = 0;
     }
-    tp = 80;
-
-    if (m.status & status_new_net) {
-      tp--;
-      if (static_cast<int>(strlen(m.title)) <= tp) {
-        nn = m.title[tp + 1];
-      } else {
-        nn = 0;
-      }
-    } else {
-      nn = 0;
-    }
-
-    set_net_num(nn);
+    set_net_num(network_number_from(&m));
 
     // Hope this isn't killed in the future
     strcpy(junk.title, m.title);

--- a/bbs/readmail.cpp
+++ b/bbs/readmail.cpp
@@ -37,10 +37,12 @@
 #include "core/textfile.h"
 #include "core/wwivassert.h"
 #include "sdk/filenames.h"
+#include "sdk/message_utils_wwiv.h"
 
 using std::string;
 using std::unique_ptr;
 using namespace wwiv::strings;
+using namespace wwiv::sdk::msgapi;
 
 // Local Functions
 bool same_email(tmpmailrec * tm, mailrec * m);
@@ -309,12 +311,10 @@ void delete_attachment(unsigned long daten, int forceit) {
 }
 
 void readmail(int mode) {
-  int i, i1, i2, i3, curmail = 0, tp, nn = 0, delme;
+  int i, i1, i2, i3, curmail = 0, nn = 0, delme;
   bool done, okmail;
-  unsigned short xx;
   char s[201], s1[205], s2[81], *ss2, mnu[81];
   mailrec m, m1;
-  postrec p;
   char ch;
   long len, num_mail, num_mail1;
   int nUserNumber, nSystemNumber;
@@ -393,20 +393,7 @@ void readmail(int mode) {
         continue;
       }
 
-      tp = 80;
-      if (m.status & status_source_verified) {
-        tp -= 2;
-      }
-      if (m.status & status_new_net) {
-        tp -= 1;
-        if (static_cast< int >(strlen(m.title)) <= tp) {
-          nn = static_cast< unsigned char >(m.title[tp + 1]);
-        } else {
-          nn = 0;
-        }
-      } else {
-        nn = 0;
-      }
+      nn = network_number_from(&m);
       sprintf(s, "|#2%3d%s|#7%c|#1 ", i + 1, m.status & status_seen ? " " : "|#3*", okansi() ? '\xB3' : '|');
 
       if ((m.anony & anony_sender) && ((ss.ability & ability_read_email_anony) == 0)) {
@@ -541,18 +528,16 @@ void readmail(int mode) {
       } else {
         net_email_name[0] = '\0';
       }
-      tp = 80;
       if (m.status & status_source_verified) {
-        tp -= 2;
-        if (static_cast<int>(strlen(m.title)) <= tp) {
-          xx = *(short *)(m.title + tp + 1);
+        int sv_type = source_verfied_type(&m);
+        if (sv_type > 0) {
           strcpy(s, "-=> Source Verified Type ");
-          sprintf(s + strlen(s), "%u", xx);
-          if (xx == 1) {
+          sprintf(s + strlen(s), "%u", sv_type);
+          if (sv_type == 1) {
             strcat(s, " (From NC)");
-          } else if (xx > 256 && xx < 512) {
+          } else if (sv_type > 256 && sv_type < 512) {
             strcpy(s2, " (From GC-");
-            sprintf(s2 + strlen(s2), "%d)", xx - 256);
+            sprintf(s2 + strlen(s2), "%d)", sv_type - 256);
             strcat(s, s2);
           }
         } else {
@@ -563,13 +548,7 @@ void readmail(int mode) {
           pla(s, &abort);
         }
       }
-      nn = 0;
-      if (m.status & status_new_net) {
-        tp -= 1;
-        if (static_cast<int>(strlen(m.title)) <= tp) {
-          nn = m.title[ tp + 1 ];
-        }
-      }
+      nn = network_number_from(&m);
       set_net_num(nn);
       int nFromSystem = 0;
       int nFromUser = 0;
@@ -821,6 +800,8 @@ void readmail(int mode) {
           if (i != -1) {
             unique_ptr<char[]> b(readfile(&(m.msg), "email", &len));
 
+            postrec p;
+            memset(&p, 0, sizeof(postrec));
             strcpy(p.title, m.title);
             p.anony = m.anony;
             p.ownersys = m.fromsys;

--- a/bbs/sysopf.cpp
+++ b/bbs/sysopf.cpp
@@ -39,13 +39,15 @@
 #include "core/strings.h"
 #include "core/wwivassert.h"
 #include "sdk/filenames.h"
+#include "sdk/message_utils_wwiv.h"
 
 using std::string;
 using std::unique_ptr;
 using wwiv::core::IniFile;
 using wwiv::core::FilePath;
-using wwiv::strings::StringPrintf;
 
+using namespace wwiv::strings;
+using namespace wwiv::sdk::msgapi;
 
 bool isr1(int nUserNumber, int nNumUsers, const char *pszName) {
   int cp = 0;
@@ -689,24 +691,9 @@ void mailr() {
         do {
           WUser user;
           application()->users()->ReadUser(&user, m.touser);
-          bout << "|#9  To|#7: |#" << session()->GetMessageColor() << user.GetUserNameAndNumber(
-                               m.touser) << wwiv::endl;
-          int tp = 80;
-          int nn = 0;
-          if (m.status & status_source_verified) {
-            tp -= 2;
-          }
-          if (m.status & status_new_net) {
-            tp -= 1;
-            if (wwiv::strings::GetStringLength(m.title) <= tp) {
-              nn = m.title[tp + 1];
-            } else {
-              nn = 0;
-            }
-          } else {
-            nn = 0;
-          }
-          set_net_num(nn);
+          bout << "|#9  To|#7: |#" << session()->GetMessageColor() 
+               << user.GetUserNameAndNumber(m.touser) << wwiv::endl;
+          set_net_num(network_number_from(&m));
           bout << "|#9Subj|#7: |#" << session()->GetMessageColor() << m.title << wwiv::endl;
           if (m.status & status_file) {
             File attachDat(syscfg.datadir, ATTACH_DAT);

--- a/core/core.vcxproj
+++ b/core/core.vcxproj
@@ -115,6 +115,7 @@
     <ClInclude Include="file.h" />
     <ClInclude Include="textfile.h" />
     <ClInclude Include="version.h" />
+    <ClInclude Include="wfndfile.h" />
     <ClInclude Include="wwivassert.h" />
     <ClInclude Include="wwivport.h" />
   </ItemGroup>

--- a/init/networks.cpp
+++ b/init/networks.cpp
@@ -125,11 +125,11 @@ static bool del_net(CursesWindow* window, int nn) {
       for (int i1 = 1; i1 <= initinfo.nNumMsgsInCurrentSub; i1++) {
         postrec* p = get_post(i1);
         if (p->status & status_post_new_net) {
-          if (p->title[80] == nn) {
-            p->title[80] = -1;
+          if (p->network_number == nn) {
+            p->network_number = -1;
             write_post(i1, p);
-          } else if (p->title[80] > nn) {
-            p->title[80]--;
+          } else if (p->network_number > nn) {
+            p->network_number--;
             write_post(i1, p);
           }
         }
@@ -147,15 +147,23 @@ static bool del_net(CursesWindow* window, int nn) {
       emailfile.Seek(r * sizeof(mailrec), File::seekBegin);
       emailfile.Read(&m, sizeof(mailrec));
       if (((m.tosys != 0) || (m.touser != 0)) && m.fromsys) {
-        int i = (m.status & status_source_verified) ? 78 : 80;
-        if ((int) strlen(m.title) >= i) {
-          m.title[i] = m.title[i - 1] = 0;
+        if (strlen(m.title) >= WWIV_MESSAGE_TITLE_LENGTH) {
+          // always trim to WWIV_MESSAGE_TITLE_LENGTH now.
+          m.title[71] = 0;
         }
         m.status |= status_new_net;
-        if (m.title[i] == nn) {
-          m.title[i] = -1;
-        } else if (m.title[i] > nn) {
-          m.title[i]--;
+        if (m.status & status_source_verified) {
+          if (m.source_verified_net_number == nn) {
+            m.source_verified_net_number = -1;
+          } else if (m.source_verified_net_number > nn) {
+            m.source_verified_net_number--;
+          }
+        } else {
+          if (m.network_number == nn) {
+            m.network_number = -1;
+          } else if (m.network_number > nn) {
+            m.network_number--;
+          }
         }
         emailfile.Seek(r * sizeof(mailrec), File::seekBegin);
         emailfile.Write(&m, sizeof(mailrec));
@@ -219,8 +227,8 @@ static bool insert_net(CursesWindow* window, int nn) {
       for (int i1 = 1; i1 <= initinfo.nNumMsgsInCurrentSub; i1++) {
         postrec* p = get_post(i1);
         if (p->status & status_post_new_net) {
-          if (p->title[80] >= nn) {
-            p->title[80]++;
+          if (p->network_number >= nn) {
+            p->network_number++;
             write_post(i1, p);
           }
         }
@@ -238,13 +246,19 @@ static bool insert_net(CursesWindow* window, int nn) {
       emailfile.Seek(sizeof(mailrec) * r, File::seekBegin);
       emailfile.Read(&m, sizeof(mailrec));
       if (((m.tosys != 0) || (m.touser != 0)) && m.fromsys) {
-        int i = (m.status & status_source_verified) ? 78 : 80;
-        if ((int) strlen(m.title) >= i) {
-          m.title[i] = m.title[i - 1] = 0;
+        if (strlen(m.title) >= WWIV_MESSAGE_TITLE_LENGTH) {
+          // always trim to WWIV_MESSAGE_TITLE_LENGTH now.
+          m.title[71] = 0;
         }
         m.status |= status_new_net;
-        if (m.title[i] >= nn) {
-          m.title[i]++;
+        if (m.status & status_source_verified) {
+          if (m.source_verified_net_number >= nn) {
+            m.source_verified_net_number++;
+          }
+        } else {
+          if (m.network_number >= nn) {
+            m.network_number++;
+          }
         }
         emailfile.Seek(sizeof(mailrec) * r, File::seekBegin);
         emailfile.Write(&m, sizeof(mailrec));

--- a/init/networks.cpp
+++ b/init/networks.cpp
@@ -125,11 +125,11 @@ static bool del_net(CursesWindow* window, int nn) {
       for (int i1 = 1; i1 <= initinfo.nNumMsgsInCurrentSub; i1++) {
         postrec* p = get_post(i1);
         if (p->status & status_post_new_net) {
-          if (p->network_number == nn) {
-            p->network_number = -1;
+          if (p->network_msg.net_number == nn) {
+            p->network_msg.net_number = -1;
             write_post(i1, p);
-          } else if (p->network_number > nn) {
-            p->network_number--;
+          } else if (p->network_msg.net_number > nn) {
+            p->network_msg.net_number--;
             write_post(i1, p);
           }
         }
@@ -153,16 +153,16 @@ static bool del_net(CursesWindow* window, int nn) {
         }
         m.status |= status_new_net;
         if (m.status & status_source_verified) {
-          if (m.source_verified_net_number == nn) {
-            m.source_verified_net_number = -1;
-          } else if (m.source_verified_net_number > nn) {
-            m.source_verified_net_number--;
+          if (m.src_verified_msg.net_number == nn) {
+            m.src_verified_msg.net_number = -1;
+          } else if (m.src_verified_msg.net_number > nn) {
+            m.src_verified_msg.net_number--;
           }
         } else {
-          if (m.network_number == nn) {
-            m.network_number = -1;
-          } else if (m.network_number > nn) {
-            m.network_number--;
+          if (m.network_msg.net_number == nn) {
+            m.network_msg.net_number = -1;
+          } else if (m.network_msg.net_number > nn) {
+            m.network_msg.net_number--;
           }
         }
         emailfile.Seek(r * sizeof(mailrec), File::seekBegin);
@@ -227,8 +227,8 @@ static bool insert_net(CursesWindow* window, int nn) {
       for (int i1 = 1; i1 <= initinfo.nNumMsgsInCurrentSub; i1++) {
         postrec* p = get_post(i1);
         if (p->status & status_post_new_net) {
-          if (p->network_number >= nn) {
-            p->network_number++;
+          if (p->network_msg.net_number >= nn) {
+            p->network_msg.net_number++;
             write_post(i1, p);
           }
         }
@@ -252,12 +252,12 @@ static bool insert_net(CursesWindow* window, int nn) {
         }
         m.status |= status_new_net;
         if (m.status & status_source_verified) {
-          if (m.source_verified_net_number >= nn) {
-            m.source_verified_net_number++;
+          if (m.src_verified_msg.net_number >= nn) {
+            m.src_verified_msg.net_number++;
           }
         } else {
-          if (m.network_number >= nn) {
-            m.network_number++;
+          if (m.network_msg.net_number >= nn) {
+            m.network_msg.net_number++;
           }
         }
         emailfile.Seek(sizeof(mailrec) * r, File::seekBegin);

--- a/init/subacc.cpp
+++ b/init/subacc.cpp
@@ -78,6 +78,7 @@ bool iscan1(int si, subboardrec *subboards) {
   // Initializes use of a sub value (subboards[], not usub[]).  If quick, then
   // don't worry about anything detailed, just grab qscan info.
   postrec p;
+  memset(&p, 0, sizeof(postrec));
 
   // forget it if an invalid sub #
   if (si < 0 || si >= initinfo.num_subs) {

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -5,6 +5,9 @@ include_directories(..)
 
 set(COMMON_SOURCES
   config.cpp
+  message_utils_wwiv.cpp
+  msgapi.cpp
+  msgapi_wwiv.cpp
   networks.cpp
   phone_numbers.cpp
   )

--- a/sdk/message_utils_wwiv.cpp
+++ b/sdk/message_utils_wwiv.cpp
@@ -1,0 +1,33 @@
+/**************************************************************************/
+/*                                                                        */
+/*                          WWIV Version 5.x                              */
+/*               Copyright (C)2015, WWIV Software Services                */
+/*                                                                        */
+/*    Licensed  under the  Apache License, Version  2.0 (the "License");  */
+/*    you may not use this  file  except in compliance with the License.  */
+/*    You may obtain a copy of the License at                             */
+/*                                                                        */
+/*                http://www.apache.org/licenses/LICENSE-2.0              */
+/*                                                                        */
+/*    Unless  required  by  applicable  law  or agreed to  in  writing,   */
+/*    software  distributed  under  the  License  is  distributed on an   */
+/*    "AS IS"  BASIS, WITHOUT  WARRANTIES  OR  CONDITIONS OF ANY  KIND,   */
+/*    either  express  or implied.  See  the  License for  the specific   */
+/*    language governing permissions and limitations under the License.   */
+/**************************************************************************/
+#include "sdk/message_utils_wwiv.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "sdk/vardec.h"
+
+namespace wwiv {
+namespace sdk {
+namespace msgapi {
+
+
+}  // namespace msgapi
+}  // namespace sdk
+}  // namespace wwiv

--- a/sdk/message_utils_wwiv.h
+++ b/sdk/message_utils_wwiv.h
@@ -31,15 +31,15 @@ uint8_t network_number_from(const M* m) {
     return 0;
   }
   if (m->status & status_source_verified) {
-    return m->source_verified_net_number;
+    return m->src_verified_msg.net_number;
   }
-  return m->network_number;
+  return m->network_msg.net_number;
 }
 
 template<typename M>
 uint8_t source_verfied_type(const M* m) {
   if ((m->status & status_new_net) && (m->status & status_source_verified)) {
-    return m->source_verified_type;
+    return m->src_verified_msg.source_verified_type;
   }
   return 0;
 }

--- a/sdk/message_utils_wwiv.h
+++ b/sdk/message_utils_wwiv.h
@@ -1,0 +1,53 @@
+/**************************************************************************/
+/*                                                                        */
+/*                          WWIV Version 5.0x                             */
+/*               Copyright (C)2015, WWIV Software Services                */
+/*                                                                        */
+/*    Licensed  under the  Apache License, Version  2.0 (the "License");  */
+/*    you may not use this  file  except in compliance with the License.  */
+/*    You may obtain a copy of the License at                             */
+/*                                                                        */
+/*                http://www.apache.org/licenses/LICENSE-2.0              */
+/*                                                                        */
+/*    Unless  required  by  applicable  law  or agreed to  in  writing,   */
+/*    software  distributed  under  the  License  is  distributed on an   */
+/*    "AS IS"  BASIS, WITHOUT  WARRANTIES  OR  CONDITIONS OF ANY  KIND,   */
+/*    either  express  or implied.  See  the  License for  the specific   */
+/*    language governing permissions and limitations under the License.   */
+/**************************************************************************/
+#ifndef __INCLUDED_SDK_MESSAGE_UTILS_WWIV_H__
+#define __INCLUDED_SDK_MESSAGE_UTILS_WWIV_H__
+
+#include <cstdint>
+#include "sdk/vardec.h"
+
+namespace wwiv {
+namespace sdk {
+namespace msgapi {
+
+template<typename M>
+uint8_t network_number_from(const M* m) {
+  if (!(m->status & status_new_net)) {
+    return 0;
+  }
+  if (m->status & status_source_verified) {
+    return m->source_verified_net_number;
+  }
+  return m->network_number;
+}
+
+template<typename M>
+uint8_t source_verfied_type(const M* m) {
+  if ((m->status & status_new_net) && (m->status & status_source_verified)) {
+    return m->source_verified_type;
+  }
+  return 0;
+}
+
+
+}  // namespace msgapi
+}  // namespace sdk
+}  // namespace wwiv
+
+
+#endif  // __INCLUDED_SDK_MESSAGE_UTILS_WWIV_H__

--- a/sdk/sdk.vcxproj
+++ b/sdk/sdk.vcxproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ClInclude Include="config.h" />
     <ClInclude Include="filenames.h" />
+    <ClInclude Include="message_utils_wwiv.h" />
     <ClInclude Include="msdos_stdint.h" />
     <ClInclude Include="msgapi.h" />
     <ClInclude Include="msgapi_wwiv.h" />
@@ -23,6 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="config.cpp" />
+    <ClCompile Include="message_utils_wwiv.cpp" />
     <ClCompile Include="msgapi.cpp" />
     <ClCompile Include="msgapi_wwiv.cpp" />
     <ClCompile Include="networks.cpp" />

--- a/sdk/sdk.vcxproj.filters
+++ b/sdk/sdk.vcxproj.filters
@@ -28,6 +28,9 @@
     <ClInclude Include="msgapi_wwiv.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="message_utils_wwiv.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">
@@ -51,6 +54,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="msgapi_wwiv.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="message_utils_wwiv.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/sdk/vardec.h
+++ b/sdk/vardec.h
@@ -480,17 +480,21 @@ struct smalrec {
 
 // TYPE TO TELL WHERE A MESSAGE IS STORED
 struct messagerec {
-  uint8_t storage_type;                 // how it is stored
-  uint32_t stored_as;                    // where it is stored
+  uint8_t storage_type;                 // how it is stored (type, 1 or 2)
+  uint32_t stored_as;                   // where it is stored (type specific)
 };
 
 
 // DATA HELD FOR EVERY POST
 struct postrec {
-  char title[81];                             // title of post
+  char title[72];                       // title of post
+  uint8_t padding_from_title[6];
+  uint8_t source_verified_net_number;
+  uint8_t unused_between_netnum;
+  uint8_t network_number;               // network number for the post
 
   uint8_t anony,                        // anony-stat of message
-           status;                                 // bit-mapped status
+          status;                       // bit-mapped status
 
   uint16_t ownersys,                    // what system it came from
            owneruser;                              // who posted it
@@ -505,19 +509,23 @@ struct postrec {
 
 // DATA HELD FOR EVERY E-MAIL OR F-BACK
 struct mailrec {
-  char title[81];                             // E-mail title
+  char title[72];                       // title of message
+  uint8_t padding_from_title[6];
+  uint8_t source_verified_net_number;
+  uint8_t source_verified_type;
+  uint8_t network_number;               // network number for the message
 
   uint8_t anony,                        // anonymous mail?
-           status;                                 // status for e-mail
+          status;                       // status for e-mail
 
   uint16_t fromsys,                     // originating system
-           fromuser,                               // originating user
-           tosys,                                  // destination system
-           touser;                                 // destination user
+           fromuser,                    // originating user
+           tosys,                       // destination system
+           touser;                      // destination user
 
-  uint32_t daten;                        // date it was sent
+  uint32_t daten;                       // date it was sent
 
-  messagerec msg;                             // where to find it
+  messagerec msg;                       // where to find it
 };
 
 // USED IN READMAIL TO STORE EMAIL INFO
@@ -856,7 +864,7 @@ enum xfertype {
 #define NUM_ONLY            1
 #define UPPER_ONLY          2
 #define ALL                 4
-#define SET                   8
+#define SET                 8
 
 struct ext_desc_type {
   char name[13];
@@ -907,6 +915,8 @@ struct languagerec {
 
 #define SUBCONF_TYPE uint16_t
 #define MAX_CONFERENCES 26
+
+#define WWIV_MESSAGE_TITLE_LENGTH 72
 
 struct confrec {
   unsigned char designator,                 // A to Z?

--- a/sdk/vardec.h
+++ b/sdk/vardec.h
@@ -489,9 +489,16 @@ struct messagerec {
 struct postrec {
   char title[72];                       // title of post
   uint8_t padding_from_title[6];
-  uint8_t source_verified_net_number;
-  uint8_t unused_between_netnum;
-  uint8_t network_number;               // network number for the post
+  union {
+    struct source_verified_message_t {
+      uint8_t net_number;               // network number for the message
+      uint16_t source_verified_type;
+    } src_verified_msg;
+    struct network_message_t {
+      uint16_t unused_padding;
+      uint8_t net_number;               // network number for the message
+    } network_msg;
+  };
 
   uint8_t anony,                        // anony-stat of message
           status;                       // bit-mapped status
@@ -511,9 +518,16 @@ struct postrec {
 struct mailrec {
   char title[72];                       // title of message
   uint8_t padding_from_title[6];
-  uint8_t source_verified_net_number;
-  uint8_t source_verified_type;
-  uint8_t network_number;               // network number for the message
+  union {
+    struct source_verified_message_t {
+      uint8_t net_number;               // network number for the message
+      uint16_t source_verified_type;
+    } src_verified_msg;
+    struct network_message_t {
+      uint16_t unused_padding;
+      uint8_t net_number;               // network number for the message
+    } network_msg;
+  };
 
   uint8_t anony,                        // anonymous mail?
           status;                       // status for e-mail


### PR DESCRIPTION
Moves out of the title field the network number, and source verified post information.  Made a new union containing the data so it's easily understandable.

Added a utility to get this data from a mailrec or postrec, make it part of the msgapi
