### PR TITLE
msgbase.cpp should have included a line to set the user_number for the

### DIFF
--- a/bbs/msgbase.cpp
+++ b/bbs/msgbase.cpp
@@ -641,6 +641,7 @@ void email(const string& title, int user_number, int system_number, bool forceit
 
   if (!cc) {
     email.system_number = system_number;
+    email.user_number = user_number;
     email.from_network_number = session()->net_num();
     sendout_email(email);
     return;


### PR DESCRIPTION
remote system  This was broken when adding a structure to
sendout_email
Fixes https://github.com/wwivbbs/wwiv/issues/473
