### PR TITLE
Change default path to WWIV Installation Guide

### DIFF
--- a/WWIV5TelnetServer/WWIV5TelnetServer/App.config
+++ b/WWIV5TelnetServer/WWIV5TelnetServer/App.config
@@ -66,10 +66,10 @@
                 <value>4</value>
             </setting>
             <setting name="executable" serializeAs="String">
-                <value>C:\bbs\bbs.exe</value>
+                <value>C:\wwiv\bbs.exe</value>
             </setting>
             <setting name="homeDirectory" serializeAs="String">
-                <value>C:\bbs</value>
+                <value>C:\wwiv</value>
             </setting>
             <setting name="parameters" serializeAs="String">
                 <value>-XT -H@H -N@N</value>


### PR DESCRIPTION
Change c:\bbs to c:\wwiv as Install Guide suggests this path as its example.
