### PR TITLE
since some compilers (msvc) aliases std::size to ::size, doing

### DIFF
--- a/bbs/subreq.cpp
+++ b/bbs/subreq.cpp
@@ -23,9 +23,12 @@
 #include "bbs/email.h"
 #include "bbs/fcns.h"
 #include "bbs/vars.h"
+#include "core/stl.h"
 #include "core/strings.h"
 #include "core/textfile.h"
 #include "sdk/filenames.h"
+
+using namespace wwiv::stl;
 
 bool display_sub_categories();
 int find_hostfor(char *type, short *ui, char *description, short *opt);
@@ -228,7 +231,7 @@ void sub_xtr_add(int n, int nn) {
   int onxi, odci, ii, gc;
 
   // nn may be -1
-  while (nn >= static_cast<int>(session()->xsubs[n].nets.size())) {
+  while (nn >= size_int(session()->xsubs[n].nets)) {
     xtrasubsnetrec xnp;
     memset(&xnp, 0, sizeof(xtrasubsnetrec));
     session()->xsubs[n].nets.push_back(xnp);
@@ -391,7 +394,7 @@ void sub_xtr_add(int n, int nn) {
       }
     }
   }
-  if (nn == -1 || nn >= static_cast<int>(session()->xsubs[n].nets.size())) {
+  if (nn == -1 || nn >= size_int(session()->xsubs[n].nets)) {
     // nn will be -1 when adding a new sub.
     session()->xsubs[n].nets.push_back(xnp);
   } else {

--- a/bbs/subxtr.cpp
+++ b/bbs/subxtr.cpp
@@ -31,7 +31,7 @@
 
 using std::string;
 using std::vector;
-using wwiv::stl::size;
+using namespace wwiv::stl;
 using namespace wwiv::strings;
 
 static xtrasubsnetrec *xsubsn;
@@ -94,7 +94,7 @@ bool read_subs_xtr(const std::vector<net_networks_rec>& net_networks, const std:
     switch (identifier) {
     case '!': {                        /* sub idx */
       curn = atoi(line.c_str());
-      if (curn >= wwiv::stl::size(subs)) {
+      if (curn >= size_int(subs)) {
         // Bad number on ! line.
         curn = -1;
         break;

--- a/core/stl.h
+++ b/core/stl.h
@@ -72,10 +72,29 @@ const typename C::mapped_type get_or_default(C c,
 }
 
 template <typename C>
-const signed int size(C c) {
+const signed int size_int(C c) {
+  return size_int32(c);
+}
+
+template <typename C>
+const int32_t size_int32(C c) {
   const auto size = c.size();
-  WWIV_ASSERT(size <= static_cast<C::size_type>(std::numeric_limits<signed int>::max()));
-  return static_cast<signed int>(size);
+  WWIV_ASSERT(size <= static_cast<C::size_type>(std::numeric_limits<int32_t>::max()));
+  return static_cast<int32_t>(size);
+}
+
+template <typename C>
+const int16_t size_int16(C c) {
+  const auto size = c.size();
+  WWIV_ASSERT(size <= static_cast<C::size_type>(std::numeric_limits<int16_t>::max()));
+  return static_cast<int16_t>(size);
+}
+
+template <typename C>
+const int8_t size_int8(C c) {
+  const auto size = c.size();
+  WWIV_ASSERT(size <= static_cast<C::size_type>(std::numeric_limits<int8_t>::max()));
+  return static_cast<int8_t>(size);
 }
 
 }  // namespace stl

--- a/core_test/stl_test.cpp
+++ b/core_test/stl_test.cpp
@@ -75,7 +75,28 @@ TEST(StlTest, Contains_MapConstStringStrings) {
 
 TEST(StlTest, SizeAsInt) {
   vector<int> v = {1, 2, 3};
-  auto vs = wwiv::stl::size(v);
+  auto vs = size_int(v);
   EXPECT_EQ(3, vs);
   EXPECT_STREQ("int", typeid(vs).name());
+}
+
+TEST(StlTest, SizeAsInt32) {
+  vector<int> v = {1, 2, 3};
+  auto vs = size_int32(v);
+  EXPECT_EQ(3, vs);
+  EXPECT_STREQ("int", typeid(vs).name());
+}
+
+TEST(StlTest, SizeAsInt16) {
+  vector<int> v = {1, 2, 3};
+  auto vs = size_int16(v);
+  EXPECT_EQ(3, vs);
+  EXPECT_STREQ("short", typeid(vs).name());
+}
+
+TEST(StlTest, SizeAsInt8) {
+  vector<int> v = {1, 2, 3};
+  auto vs = size_int8(v);
+  EXPECT_EQ(3, vs);
+  EXPECT_STREQ("signed char", typeid(vs).name());
 }


### PR DESCRIPTION
using namespace wwiv::stl causes a collision for size.  So, let's call
it something else (size_int, since that is what it is) instead.  This way
we don't have to hunt down which system headers are doing something dumb
like "using namespace std"
