### PR TITLE
cleanup read/write code a bit.  Simplify a few things by not

### DIFF
--- a/sdk/msgapi/message_area_wwiv.h
+++ b/sdk/msgapi/message_area_wwiv.h
@@ -46,7 +46,9 @@ public:
   virtual int FindUserMessages(const std::string& user_name) override;
   virtual int number_of_messages() override;
 
-  // message specific
+  // message specific.
+  // I would return a unique_ptr here but that doesn't work with
+  // covariant return types for subclasses.
   virtual WWIVMessage* ReadMessage(int message_number) override;
   virtual WWIVMessageHeader* ReadMessageHeader(int message_number) override;
   virtual WWIVMessageText*  ReadMessageText(int message_number) override;
@@ -55,9 +57,9 @@ public:
 
 private:
   File* OpenMessageFile(const std::string msgs_filename);
-  void set_gat_section(File& file, size_t section);
-  void save_gat(File& f);
-  bool readfile(const messagerec* pMessageRecord, std::string msgs_filename, std::string* out);
+  std::vector<uint16_t> load_gat(File& file, size_t section);
+  void save_gat(File& f, size_t section, const std::vector<uint16_t>& gat);
+  bool readfile(const messagerec* msg, std::string msgs_filename, std::string* out);
   void savefile(const std::string& text, messagerec* pMessageRecord, const std::string& fileName);
   void remove_link(messagerec& msg, const std::string& fileName);
   bool add_post(const postrec& post);
@@ -66,10 +68,6 @@ private:
   const std::string text_filename_;
   bool open_ = false;
   int last_num_messages_ = 0;
-
-  // gat section used by wwiv message text files.
-  int32_t gat_section = 0;
-  std::unique_ptr<uint16_t[]> gat;
 
   static constexpr uint8_t STORAGE_TYPE = 2;
 };

--- a/sdk/msgapi/message_wwiv.cpp
+++ b/sdk/msgapi/message_wwiv.cpp
@@ -84,8 +84,9 @@ WWIVMessageText::WWIVMessageText(const std::string& text)
 
 WWIVMessageText::~WWIVMessageText() {}
 
-WWIVMessage::WWIVMessage(WWIVMessageHeader* header, WWIVMessageText* text)
-  : Message(), header_(header), text_(text) {}
+WWIVMessage::WWIVMessage(std::unique_ptr<WWIVMessageHeader> header,
+  std::unique_ptr<WWIVMessageText> text)
+  : Message(), header_(std::move(header)), text_(std::move(text)) {}
 
 WWIVMessage::~WWIVMessage() {}
 

--- a/sdk/msgapi/message_wwiv.h
+++ b/sdk/msgapi/message_wwiv.h
@@ -92,7 +92,8 @@ private:
 
 class WWIVMessage: public Message {
 public:
-  WWIVMessage(WWIVMessageHeader* header, WWIVMessageText* text);
+  WWIVMessage(std::unique_ptr<WWIVMessageHeader> header, 
+    std::unique_ptr<WWIVMessageText> text);
   ~WWIVMessage();
 
   virtual WWIVMessageHeader* header() const override { return header_.get(); }

--- a/wwivutil/messages/messages.cpp
+++ b/wwivutil/messages/messages.cpp
@@ -223,7 +223,7 @@ public:
     header->set_in_reply_to(in_reply_to);
 
     unique_ptr<WWIVMessageText> text = make_unique<WWIVMessageText>(Join(lines));
-    WWIVMessage message(header.release(), text.release());
+    WWIVMessage message(std::move(header), std::move(text));
 
     return area->AddMessage(message) ? 0 : 1;
   }


### PR DESCRIPTION
keeping gat state globally, but just load/save as needed since
that's what happens anyway.

Also use unique_ptr as parameters wherever posssible so the intent
is clear to transfer ownership.
