### PR TITLE
introduced new subfile_header_t

### DIFF
--- a/bbs/msgbase1.cpp
+++ b/bbs/msgbase1.cpp
@@ -227,7 +227,7 @@ void post() {
   }
   savefile(data.text, &m, data.aux);
 
-  postrec p;
+  postrec p{};
   memset(&p, 0, sizeof(postrec));
   strcpy(p.title, data.title.c_str());
   p.anony = static_cast<unsigned char>(data.anonymous_flag);

--- a/bbs/new_bbslist.cpp
+++ b/bbs/new_bbslist.cpp
@@ -34,7 +34,6 @@
 #include "bbs/pause.h"
 #include "bbs/printfile.h"
 #include "bbs/sysopf.h"
-#include "bbs/vars.h"  // for syscfg
 #include "bbs/wsession.h"
 #include "core/stl.h"
 #include "core/strings.h"
@@ -265,7 +264,7 @@ static string GetConnectionType(const BbsListEntry* entry, ConnectionType type) 
 static void ReadBBSList(const vector<unique_ptr<BbsListEntry>>& entries) {
   int cnt = 0;
   bout.cls();
-  bout.litebar("%s BBS List", syscfg.systemname);
+  bout.litebar("%s BBS List", session()->config()->config()->systemname);
   for (const auto& entry : entries) {
     bout.Color((++cnt % 2) == 0 ? 1 : 9);
     bout << left << setw(3) << entry->id << " : " << setw(60) << entry->name << " (" << entry->software << ")" << wwiv::endl;

--- a/bbs/qwk1.cpp
+++ b/bbs/qwk1.cpp
@@ -707,7 +707,7 @@ void process_reply_dat(char *name) {
 
 void qwk_post_text(char *text, char *title, int sub) {
   messagerec m;
-  postrec p;
+  postrec p{};
 
   int dm, f, done = 0, pass = 0;
   slrec ss;

--- a/bbs/readmail.cpp
+++ b/bbs/readmail.cpp
@@ -813,8 +813,7 @@ void readmail(int mode) {
             string b;
             readfile(&(m.msg), "email", &b);
 
-            postrec p;
-            memset(&p, 0, sizeof(postrec));
+            postrec p{};
             strcpy(p.title, m.title);
             p.anony = m.anony;
             p.ownersys = m.fromsys;

--- a/bbs/subacc.cpp
+++ b/bbs/subacc.cpp
@@ -85,8 +85,7 @@ bool open_sub(bool wr) {
 
 uint32_t WWIVReadLastRead(int sub_number) {
   // open file, and create it if necessary
-  postrec p;
-  memset(&p, 0, sizeof(postrec));
+  postrec p{};
 
   File subFile(session()->config()->datadir(), StrCat(session()->subboards[sub_number].filename, ".sub"));
   if (!subFile.Exists()) {
@@ -120,7 +119,7 @@ uint32_t WWIVReadLastRead(int sub_number) {
 // Initializes use of a sub value (session()->subboards[], not usub[]).  If quick, then
 // don't worry about anything detailed, just grab qscan info.
 bool iscan1(int sub_index) {
-  postrec p;
+  postrec p{};
 
   // forget it if an invalid sub #
   if (sub_index < 0 || sub_index >= size_int(session()->subboards)) {

--- a/bbs/subedit.cpp
+++ b/bbs/subedit.cpp
@@ -76,25 +76,29 @@ static void save_subs() {
   set_net_num(nSavedNetNum);
 }
 
-static string boarddata(size_t n) {
-  subboardrec r = session()->subboards[n];
-  char x = SPACE;
+static string GetAr(subboardrec r, const string& default_value) {
   if (r.ar != 0) {
-    for (char i = 0; i < 16; i++) {
+    for (int i = 0; i < 16; i++) {
       if ((1 << i) & r.ar) {
-        x = 'A' + i;
+        return string(1, static_cast<char>('A' + i));
       }
     }
   }
+  return default_value;
+}
+
+static string boarddata(size_t n) {
+  subboardrec r = session()->subboards[n];
   string stype;
   if (n < session()->xsubs.size()) {
-    const xtrasubsrec& xsnr = session()->xsubs[n];;
+    const xtrasubsrec& xsnr = session()->xsubs[n];
     if (!xsnr.nets.empty()) {
       stype = xsnr.nets[0].stype;
     }
   }
-  return StringPrintf("|#2%4d |#9%1c  |#1%-37.37s |#2%-8s |#9%-3d %-3d %-2d %-5d %7s",
-          n, x, stripcolors(r.name), r.filename, r.readsl, r.postsl, r.age,
+  string ar = GetAr(r, " ");
+  return StringPrintf("|#2%4d |#9%1s  |#1%-37.37s |#2%-8s |#9%-3d %-3d %-2d %-5d %7s",
+          n, ar.c_str(), stripcolors(r.name), r.filename, r.readsl, r.postsl, r.age,
           r.maxmsgs, stype.c_str());
 }
 
@@ -135,17 +139,6 @@ static string GetAnon(const subboardrec& r) {
   default:
     return "Real screwed up";
   }
-}
-
-string GetAr(subboardrec r) {
-  if (r.ar != 0) {
-    for (int i = 0; i < 16; i++) {
-      if ((1 << i) & r.ar) {
-        return string(1, static_cast<char>('A' + i));
-      }
-    }
-  }
-  return "None.";
 }
 
 void DisplayNetInfo(size_t nSubNum) {
@@ -219,7 +212,7 @@ static void modify_sub(int n) {
     bout << "|#9F) Anony      : |#2" << GetAnon(r) << wwiv::endl;
     bout << "|#9G) Min. Age   : |#2" << static_cast<int>(r.age) << wwiv::endl;
     bout << "|#9H) Max Msgs   : |#2" << r.maxmsgs << wwiv::endl;
-    bout << "|#9I) AR         : |#2" << GetAr(r) << wwiv::endl;
+    bout << "|#9I) AR         : |#2" << GetAr(r, "None.") << wwiv::endl;
     bout << "|#9J) Net info   : |#2";
     DisplayNetInfo(n);
 
@@ -406,7 +399,7 @@ static void modify_sub(int n) {
         bout << static_cast<char>('a' + session()->xsubs[n].nets.size() - 1) 
              << "), <space>=Quit? ";
         string charstring;
-        for (int i = 0; i < session()->xsubs[n].nets.size(); i++) {
+        for (size_t i = 0; i < session()->xsubs[n].nets.size(); i++) {
           charstring.push_back(static_cast<char>('A' + i));
         }
         bout.Color(0);

--- a/core/version.cpp
+++ b/core/version.cpp
@@ -17,15 +17,16 @@
 /*                                                                        */
 /**************************************************************************/
 
+#include <cstdint>
+
 // Version String
 const char *wwiv_version = "5.1.0";
 
 // Build Information
 const char *beta_version = ".development";
 
-// this is used to set the status.wwiv_version
-// leaving at 431 until we break file compatability
-unsigned short wwiv_num_version = 431;
+// this is used to set the status.wwiv_version.
+uint16_t wwiv_num_version = 510;
 
 // Data/time of this build
 const char *wwiv_date = __DATE__ ", " __TIME__;

--- a/core/version.h
+++ b/core/version.h
@@ -15,12 +15,14 @@
 /*    either  express  or implied.  See  the  License for  the specific   */
 /*    language governing permissions and limitations under the License.   */
 /**************************************************************************/
-#ifndef __INCLUDED_BBS_VERSION_H__
-#define __INCLUDED_BBS_VERSION_H__
+#ifndef __INCLUDED_CORE_VERSION_H__
+#define __INCLUDED_CORE_VERSION_H__
+
+#include <cstdint>
 
 extern const char *wwiv_version;
 extern const char *beta_version;
 extern const char *wwiv_date;
-extern unsigned short wwiv_num_version;
+extern uint16_t wwiv_num_version;
 
-#endif  // __INCLUDED_BBS_VERSION_H__
+#endif  // __INCLUDED_CORE_VERSION_H__

--- a/core/version.template
+++ b/core/version.template
@@ -4,7 +4,7 @@
 /**************************************************************************/
 /*                                                                        */
 /*                              WWIV Version 5.x                          */
-/*             Copyright (C)1998-2015, WWIV Software Services             */
+/*             Copyright (C)1998-2016, WWIV Software Services             */
 /*                                                                        */
 /*    Licensed  under the  Apache License, Version  2.0 (the "License");  */
 /*    you may not use this  file  except in compliance with the License.  */
@@ -18,7 +18,10 @@
 /*    either  express  or implied.  See  the  License for  the specific   */
 /*    language governing permissions and limitations under the License.   */
 /*                                                                        */
-/**************************************************************************/
+/**************************************************************************/a
+
+#include <cstdint>
+
 
 // Version String
 const char *wwiv_version = "5.1.0";
@@ -30,8 +33,7 @@ const char *wwiv_version = "5.1.0";
 const char *beta_version = ".<#= version #>";
 
 // this is used to set the status.wwiv_version
-// leaving at 431 until we break file compatability
-unsigned short wwiv_num_version = 431;
+unsigned short wwiv_num_version = 510;
 
 // Data/time of this build
 const char *wwiv_date = __DATE__ ", " __TIME__;

--- a/init/subacc.cpp
+++ b/init/subacc.cpp
@@ -62,7 +62,7 @@ void close_sub() {
 }
 
 bool open_sub(bool wr) {
-  postrec p;
+  postrec p{};
 
   close_sub();
 
@@ -87,8 +87,7 @@ bool open_sub(bool wr) {
 bool iscan1(int si, const vector<subboardrec>& subboards) {
   // Initializes use of a sub value (subboards[], not usub[]).  If quick, then
   // don't worry about anything detailed, just grab qscan info.
-  postrec p;
-  memset(&p, 0, sizeof(postrec));
+  postrec p{};
 
   // forget it if an invalid sub #
   if (si < 0 || si >= size_int(subboards)) {
@@ -138,7 +137,7 @@ bool iscan1(int si, const vector<subboardrec>& subboards) {
 postrec *get_post(int mn) {
   // Returns info for a post.  Maintains a cache.  Does not correct anything
   // if the sub has changed.
-  static postrec p;
+  static postrec p{};
   // error if msg # invalid
   if (mn < 1) {
     return nullptr;

--- a/sdk/msgapi/message_api_wwiv.cpp
+++ b/sdk/msgapi/message_api_wwiv.cpp
@@ -90,8 +90,7 @@ WWIVMessageArea* WWIVMessageApi::Create(const std::string& name) {
     msgs_file.SetLength(GAT_SECTION_SIZE + (75L * 1024L));
   }
 
-  postrec p;
-  memset(&p, 0, sizeof(postrec));
+  postrec p{};
   p.owneruser = 0;
   fileSub.Write(&p, sizeof(postrec));
   return new WWIVMessageArea(this, fileSub.full_pathname(), msgs_file.full_pathname());

--- a/sdk/msgapi/message_api_wwiv.cpp
+++ b/sdk/msgapi/message_api_wwiv.cpp
@@ -24,6 +24,7 @@
 
 #include "core/file.h"
 #include "core/strings.h"
+#include "core/version.h"
 #include "bbs/subacc.h"
 #include "sdk/vardec.h"
 
@@ -90,9 +91,17 @@ WWIVMessageArea* WWIVMessageApi::Create(const std::string& name) {
     msgs_file.SetLength(GAT_SECTION_SIZE + (75L * 1024L));
   }
 
-  postrec p{};
-  p.owneruser = 0;
-  fileSub.Write(&p, sizeof(postrec));
+  // Create 5.1 style sub header.
+  subfile_header_t sub_header{};
+  strcpy(sub_header.signature, "WWIV\x1A");
+  sub_header.revision = 1;
+  sub_header.wwiv_version = wwiv_num_version;
+  sub_header.daten_created = static_cast<uint32_t>(time(nullptr));
+  fileSub.Write(&sub_header, sizeof(subfile_header_t));
+  // Need to close the files before creating a new WWIVMessageArea since we
+  //  have thm locked for write, and we need to open it in the constructor.
+  fileSub.Close();
+  msgs_file.Close();
   return new WWIVMessageArea(this, fileSub.full_pathname(), msgs_file.full_pathname());
 }
 

--- a/sdk/msgapi/message_area_wwiv.cpp
+++ b/sdk/msgapi/message_area_wwiv.cpp
@@ -359,7 +359,7 @@ std::vector<uint16_t> WWIVMessageArea::load_gat(File& file, size_t section) {
     file_size = section_pos;
   }
   file.Seek(section_pos, File::seekBegin);
-  if (file_size < (section_pos + GAT_SECTION_SIZE)) {
+  if (file_size < static_cast<long>(section_pos + GAT_SECTION_SIZE)) {
     // TODO(rushfan): Check that gat is loaded.
     file.Write(&gat[0], GAT_SECTION_SIZE);
   } else {

--- a/sdk/vardec.h
+++ b/sdk/vardec.h
@@ -495,6 +495,20 @@ struct network_message_t {
   uint8_t net_number;               // network number for the message
 };
 
+struct subfile_header_t {
+  char signature[6];
+  uint16_t wwiv_version;
+  uint32_t revision;
+  uint32_t daten_created;
+  uint32_t unused_padding_for_64bit_time_t;
+  uint32_t mod_count;
+  uint32_t unused_padding_for_64bit_mod_count;
+  uint32_t password_crc32;
+  uint32_t base_message_num;
+  uint8_t padding_1[49];
+  uint32_t active_message_count;
+  uint8_t padding_2[11];
+};
 
 // DATA HELD FOR EVERY POST
 struct postrec {
@@ -1068,6 +1082,9 @@ static_assert(sizeof(directoryrec) == 141, "directoryrec == 141");
 static_assert(sizeof(smalrec) == 33, "smalrec == 33");
 static_assert(sizeof(messagerec) == 5, "messagerec == 5");
 static_assert(sizeof(postrec) == 100, "postrec == 100");
+static_assert(sizeof(subfile_header_t) == 100, "subfile_header_t == 100");
+static_assert(offsetof(postrec, owneruser) == offsetof(subfile_header_t, active_message_count),
+  "owneruser offset != active_message_count: ");
 static_assert(sizeof(mailrec) == 100, "mailrec == 100");
 static_assert(sizeof(tmpmailrec) == 15, "tmpmailrec == 15");
 static_assert(sizeof(shortmsgrec) == 85, "shortmsgrec == 85");

--- a/wwivutil/messages/messages.cpp
+++ b/wwivutil/messages/messages.cpp
@@ -90,12 +90,16 @@ public:
       config()->config()->datadir(), config()->config()->msgsdir(), networks.networks());
     if (!api->Exist(basename)) {
       clog << "Message area: '" << basename << "' does not exist." << endl;
+      clog << "Attempting to create it." << endl;
+      // Since the area does not exist, let's create it automatically
+      // like WWIV alwyas does.
+      unique_ptr<MessageArea> creator(api->Create(basename));
       return 1;
     }
 
     unique_ptr<MessageArea> area(api->Open(basename));
     if (!area) {
-      clog << "Error opening message area: '" << basename << "'." << endl;
+      clog << "Unable to Open message area: '" << basename << "'." << endl;
       return 1;
     }
 
@@ -176,7 +180,14 @@ public:
       config()->config()->datadir(), config()->config()->msgsdir(), networks.networks());
     if (!api->Exist(basename)) {
       clog << "Message area: '" << basename << "' does not exist." << endl;
-      return 1;
+      clog << "Attempting to create it." << endl;
+      // Since the area does not exist, let's create it automatically
+      // like WWIV alwyas does.
+      unique_ptr<MessageArea> creator(api->Create(basename));
+      if (!creator) {
+        clog << "Failed to create message area: " << basename << ". Exiting." << endl;
+        return 1;
+      }
     }
 
     unique_ptr<MessageArea> area(api->Open(basename));


### PR DESCRIPTION
we're still backwards compatible with tools from 4.30, 4.31 was never
released so we were claiming to be compatible with something that
doesn't exist.  510 makes more sense for this value (which is only
used by fix to see if it can run anyway)

Created subfile_header_t as the new header format for wwiv message
bases (WMB) (type-2 specifically).  It's binary compatible with what
was there before, but includes more fields than the previous
one which only used 1 field to contain the number of messages.  You can
tell that you are using the new format if you look at a .sub file with an
editor or type/cat it, it starts with "WWIV^Z".  Right now only the msgapi
will create it when creating a new message area.  Soon msgapi will start
backfilling older subs with the new header as it encounters them, and by
5.2 all subs should be in the new format. (don't worry, it's backwards
compatible by all old type-2 tools)
