### PR TITLE
add step to push to origin

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -72,10 +72,11 @@ Here's the best way to work with the WWIV git repository:
     git push
     ```
     
-3. Create a new branch off of master for your feature, enhancement, or bug fix.
+3. Create a new branch off of master for your feature, enhancement, or bug fix and let GitHub know about your branch.
 
     ```bash
     git checkout -b <MY-BRANCH-NAME>
+    git push origin <MY-BRANCH-NAME>
     ```    
 
 4. Make your changes by editing the files and committing changes to your local repository.  Please use good commit messages that explain the changes and also reference github issues as necessary.


### PR DESCRIPTION
When you use the CLI, after you checkout and create a new branch you need to push that to origin which let's github know about your branch. So if you want you can do the PRs in their site. This is also handy if you are using github branches to stage changes to dev and test environments otherwise your branches only exist locally.
