### PR TITLE
Don't allow IOSSH operations when we never fully

### DIFF
--- a/bbs/ssh.cpp
+++ b/bbs/ssh.cpp
@@ -332,6 +332,8 @@ IOSSH::IOSSH(SOCKET ssh_socket, Key& key)
   RemoteInfo& info = remote_info();
   info.username = session_.GetAndClearRemoteUserName();
   info.password = session_.GetAndClearRemotePassword();
+
+  initialized_ = true;
 }
 
 IOSSH::~IOSSH() {
@@ -401,27 +403,62 @@ bool IOSSH::ssh_initalize() {
   return true;
 }
 
-bool IOSSH::open() { return io_->open(); }
+bool IOSSH::open() { 
+  if (!initialized_) return false;
+  return io_->open(); 
+}
 
 void IOSSH::close(bool temporary) { 
+  if (!initialized_) return;
   if (!temporary) {
     session_.close();
   }
   io_->close(temporary);
 }
 
-unsigned char IOSSH::getW() { return io_->getW();  }
-bool IOSSH::dtr(bool raise) { return io_->dtr(raise);  }
-void IOSSH::purgeIn() { io_->purgeIn();  }
-unsigned int IOSSH::put(unsigned char ch) { return io_->put(ch);  }
-unsigned int IOSSH::read(char *buffer, unsigned int count) { return io_->read(buffer, count);  }
-unsigned int IOSSH::write(const char *buffer, unsigned int count, bool bNoTranslation) {
-  return io_->write(buffer, count, bNoTranslation); 
+unsigned char IOSSH::getW() { 
+  if (!initialized_) return 0;
+  return io_->getW();
 }
-bool IOSSH::carrier() { return io_->carrier(); }
-bool IOSSH::incoming() { return io_->incoming(); }
-unsigned int IOSSH::GetHandle() const { return io_->GetHandle(); }
-unsigned int IOSSH::GetDoorHandle() const { return io_->GetDoorHandle(); }
+bool IOSSH::dtr(bool raise) {
+  if (!initialized_) return false;
+  return io_->dtr(raise);
+}
+void IOSSH::purgeIn() { 
+  if (!initialized_) return;
+  io_->purgeIn();
+}
+unsigned int IOSSH::put(unsigned char ch) { 
+  if (!initialized_) return 0;
+  return io_->put(ch);
+}
+unsigned int IOSSH::read(char *buffer, unsigned int count) {
+  if (!initialized_) return 0;
+  return io_->read(buffer, count);
+}
+unsigned int IOSSH::write(const char *buffer, unsigned int count, bool bNoTranslation) {
+  if (!initialized_) return 0;
+  return io_->write(buffer, count, bNoTranslation);
+}
+bool IOSSH::carrier() { 
+  if (!initialized_) return false;
+  return io_->carrier(); 
+}
+
+bool IOSSH::incoming() {
+  if (!initialized_) return false;
+  return io_->incoming();
+}
+
+unsigned int IOSSH::GetHandle() const { 
+  if (!initialized_) return false;
+  return io_->GetHandle();
+}
+
+unsigned int IOSSH::GetDoorHandle() const {
+  if (!initialized_) return false;
+  return io_->GetDoorHandle();
+}
 
 }
 }

--- a/bbs/ssh.h
+++ b/bbs/ssh.h
@@ -90,6 +90,7 @@ public:
 private:
   std::thread ssh_receive_thread_;
   std::thread ssh_send_thread_;
+  bool initialized_ = false;
   std::unique_ptr<RemoteSocketIO> io_;
   SOCKET ssh_socket_;
   SOCKET plain_socket_;

--- a/bbs/wsession.cpp
+++ b/bbs/wsession.cpp
@@ -1192,10 +1192,17 @@ int WSession::Run(int argc, char *argv[]) {
   InitializeBBS();
   localIO()->UpdateNativeTitleBar(this);
 
+  bool remote_opened = false;
   // If we are telnet...
   if (type == CommunicationType::TELNET || type == CommunicationType::SSH) {
     ok_modem_stuff = true;
-    remoteIO()->open();
+    remote_opened = remoteIO()->open();
+  }
+
+  if (!remote_opened) {
+    // Remote side disconnected.
+    clog << "Remote side disconnected." << std::endl;
+    exit(m_nOkLevel);
   }
 
   if (num_min > 0) {


### PR DESCRIPTION
constructed it.  return false from open on this case.
exit the bbs when we have a remote caller and failed to
open the remote IO
