### PR TITLE
use usernum in door32.sys drop file.

### DIFF
--- a/bbs/dropfile.cpp
+++ b/bbs/dropfile.cpp
@@ -348,18 +348,18 @@ void CreateDoor32SysDropFile() {
 
   TextFile file(fileName, "wt");
   if (file.IsOpen()) {
-    file.WriteFormatted("%d\n",     GetDoor32CommType());
-    file.WriteFormatted("%u\n",     GetDoorHandle());
+    file.WriteFormatted("%d\n", GetDoor32CommType());
+    file.WriteFormatted("%u\n", GetDoorHandle());
     string cspeed = GetComSpeedInDropfileFormat(com_speed);
-    file.WriteFormatted("%s\n",      cspeed.c_str());
+    file.WriteFormatted("%s\n", cspeed.c_str());
     file.WriteFormatted("WWIV %s\n", wwiv_version);
-    file.WriteFormatted("999999\n"); // we don't want to share this
-    file.WriteFormatted("%s\n",      session()->user()->GetRealName());
-    file.WriteFormatted("%s\n",      session()->user()->GetName());
-    file.WriteFormatted("%d\n",      session()->user()->GetSl());
-    file.WriteFormatted("%d\n",      60 * GetMinutesRemainingForDropFile());
-    file.WriteFormatted("%d\n",      GetDoor32Emulation());
-    file.WriteFormatted("%u\n",      session()->instance_number());
+    file.WriteFormatted("%d\n", session()->usernum);
+    file.WriteFormatted("%s\n", session()->user()->GetRealName());
+    file.WriteFormatted("%s\n", session()->user()->GetName());
+    file.WriteFormatted("%d\n", session()->user()->GetSl());
+    file.WriteFormatted("%d\n", 60 * GetMinutesRemainingForDropFile());
+    file.WriteFormatted("%d\n", GetDoor32Emulation());
+    file.WriteFormatted("%u\n", session()->instance_number());
     file.Close();
   }
 }


### PR DESCRIPTION
I was worried that since this was an elebbs spec that
some door may trash our userrec, but I don't think the
worry is warranted.

fixes https://github.com/wwivbbs/wwiv/issues/757
