### PR TITLE
Issue770 - Fix for network1 routing to other boards

### DIFF
--- a/network1/network1.cpp
+++ b/network1/network1.cpp
@@ -76,7 +76,7 @@ static void ShowHelp(CommandLine& cmdline) {
 
 static uint16_t get_forsys( const BbsListNet& b, uint16_t node) {
   auto n = b.node_config_for(node);
-  if (n->forsys) {
+  if (n != nullptr && n->forsys != 65535) {
     return n->forsys;
   }else{
     return node;

--- a/network1/network1.cpp
+++ b/network1/network1.cpp
@@ -103,8 +103,8 @@ static bool handle_packet(
     return write_packet(LOCAL_NET, net, nh, list, text);
   } else if (list.empty()) {
     // Network packet, single destination
-    const string filename = StringPrintf("s%u.net", get_forsys(nh.tosys));
-    return write_packet(CreateNetworkFileName(net, get_forsys(nh.tosys)), net, nh, list, text);
+    const string filename = StringPrintf("s%u.net", get_forsys(b, nh.tosys));
+    return write_packet(CreateNetworkFileName(net, get_forsys(b, nh.tosys)), net, nh, list, text);
   } else {
     for (const auto& node : list) {
       return write_packet(CreateNetworkFileName(net, node), net, nh, list, text);
@@ -150,7 +150,7 @@ static bool handle_file(const BbsListNet& b, const net_networks_rec& net, const 
       text.resize(nh.length);
       f.Read(&text[0], nh.length);
     }
-    if (!handle_packet(net, nh, list, text)) {
+    if (!handle_packet(b, net, nh, list, text)) {
       LOG << "error handing packet: type: " << nh.main_type;
     }
   }
@@ -213,7 +213,7 @@ int main(int argc, char** argv) {
     while (has_next) {
       const string name = s_files.GetFileName();
       LOG << "Processing: " << net.dir << name;
-      if (handle_file(net, name)) {
+      if (handle_file(b, net, name)) {
         LOG << "Deleting: " << net.dir << name;
         File::Remove(net.dir, name);
       }

--- a/network3/network3.cpp
+++ b/network3/network3.cpp
@@ -102,7 +102,7 @@ static bool send_feedback(
 
   std::ostringstream text;
   text << "\r\n";
-  TextFile feedback_hdr(net.dir, "FBACKHDR.NET", "rt");
+  TextFile feedback_hdr(net.dir, "fbackhdr.net", "rt");
   if (feedback_hdr.IsOpen()) {
     string line;
     while (feedback_hdr.ReadLine(&line)) {


### PR DESCRIPTION
network1 was creating an s*.net file based on the final destination, not the system that was the next hop, so messages would never get sent out.  Also made a filename case fix in network3 so the network health header is used again.
