### PR TITLE
Issue785 - Write to dead.net on failures

### DIFF
--- a/network2/email.cpp
+++ b/network2/email.cpp
@@ -83,7 +83,8 @@ namespace net {
 namespace network2 {
 
 bool handle_email(Context& context,
-  uint16_t to_user, const net_header_rec& nh, const string& text) {
+  uint16_t to_user, const net_header_rec& nh, 
+  std::vector<uint16_t>& list, const string& text) {
   LOG(INFO) << "==============================================================";
   ScopeExit at_exit([] {
     LOG(INFO) << "==============================================================";
@@ -122,8 +123,8 @@ bool handle_email(Context& context,
   std::unique_ptr<WWIVEmail> email(context.api.OpenEmail());
   bool added = email->AddMessage(d);
   if (!added) {
-    LOG(INFO) << "    ! ERROR adding email message.";
-    return false;
+    LOG(ERROR) << "    ! ERROR adding email message; writing to dead.net";
+    return write_packet(DEAD_NET, context.net, nh, list, text);
   }
   User user;
   context.user_manager.ReadUser(&user, d.user_number);

--- a/network2/email.h
+++ b/network2/email.h
@@ -34,7 +34,7 @@ namespace network2 {
 
 bool handle_email(Context& context,
   uint16_t to_user, const net_header_rec& nh, 
-  std::vector<uint16_t>& list, const string& text);
+  std::vector<uint16_t>& list, const std::string& text);
 
 }  // namespace network2
 }  // namespace net

--- a/network2/email.h
+++ b/network2/email.h
@@ -33,7 +33,8 @@ namespace net {
 namespace network2 {
 
 bool handle_email(Context& context,
-  uint16_t to_user, const net_header_rec& nh, const std::string& text);
+  uint16_t to_user, const net_header_rec& nh, 
+  std::vector<uint16_t>& list, const string& text);
 
 }  // namespace network2
 }  // namespace net

--- a/network2/network2.cpp
+++ b/network2/network2.cpp
@@ -129,7 +129,7 @@ static bool handle_net_info_file(const net_networks_rec& net,
   if (nh.minor_type == net_info_file) {
     // we don't know the filename
     LOG(ERROR) << "ERROR: net_info_file not supported; writing to dead.net";
-    return write_packet(DEAD_NET, context.net, nh, list, text);
+    return write_packet(DEAD_NET, net, nh, list, text);
   } else if (!filename.empty()) {
     // we know the name.
     File file(net.dir, filename);
@@ -137,7 +137,7 @@ static bool handle_net_info_file(const net_networks_rec& net,
       File::shareDenyReadWrite)) {
       // We couldn't create or open the file.
       LOG(ERROR) << "ERROR: Unable to create or open file: " << filename << " writing to dead.net";
-      return write_packet(DEAD_NET, context.net, nh, list, text);
+      return write_packet(DEAD_NET, net, nh, list, text);
     }
     file.Write(text);
     LOG(INFO) << "  + Got " << filename;
@@ -145,7 +145,7 @@ static bool handle_net_info_file(const net_networks_rec& net,
   }
   // error.
   LOG(ERROR) << "ERROR: Fell through handle_net_info_file; writing to dead.net";
-  return write_packet(DEAD_NET, context.net, nh, list, text);
+  return write_packet(DEAD_NET, net, nh, list, text);
 }
 
 static bool handle_packet(

--- a/network2/network2.cpp
+++ b/network2/network2.cpp
@@ -90,7 +90,8 @@ static void ShowHelp(CommandLine& cmdline) {
   exit(1);
 }
 
-static bool handle_ssm(Context& context, const net_header_rec& nh, const std::string& text) {
+static bool handle_ssm(Context& context, const net_header_rec& nh, 
+  std::vector<uint16_t>& list,  const std::string& text) {
   ScopeExit at_exit([] {
     VLOG(1) << "==============================================================";
   });
@@ -98,8 +99,8 @@ static bool handle_ssm(Context& context, const net_header_rec& nh, const std::st
   VLOG(1) << "  Receiving SSM for user: #" << nh.touser;
   SSM ssm(context.config, context.user_manager);
   if (!ssm.send_local(nh.touser, text)) {
-    LOG(ERROR) << "  ERROR writing SSM: '" << text << "'";
-    return false;
+    LOG(ERROR) << "  ERROR writing SSM: '" << text << "'; writing to dead.net";
+    return write_packet(DEAD_NET, context.net, nh, list, text);
   }
 
   LOG(INFO) << "    + SSM  '" << text << "'";
@@ -122,28 +123,29 @@ static string NetInfoFileName(uint16_t type) {
 }
 
 static bool handle_net_info_file(const net_networks_rec& net,
-  const net_header_rec& nh, const string& text) {
+  const net_header_rec& nh, std::vector<uint16_t>& list, const string& text) {
 
   string filename = NetInfoFileName(nh.minor_type);
   if (nh.minor_type == net_info_file) {
     // we don't know the filename
-    LOG(ERROR) << "ERROR: net_info_file not supported.";
-    return false;
+    LOG(ERROR) << "ERROR: net_info_file not supported; writing to dead.net";
+    return write_packet(DEAD_NET, context.net, nh, list, text);
   } else if (!filename.empty()) {
     // we know the name.
     File file(net.dir, filename);
     if (!file.Open(File::modeWriteOnly | File::modeBinary | File::modeCreateFile | File::modeTruncate, 
       File::shareDenyReadWrite)) {
       // We couldn't create or open the file.
-      LOG(ERROR) << "ERROR: Unable to create or open file: " << filename;
-      return false;
+      LOG(ERROR) << "ERROR: Unable to create or open file: " << filename << " writing to dead.net";
+      return write_packet(DEAD_NET, context.net, nh, list, text);
     }
     file.Write(text);
     LOG(INFO) << "  + Got " << filename;
     return true;
   }
   // error.
-  return false;
+  LOG(ERROR) << "ERROR: Fell through handle_net_info_file; writing to dead.net";
+  return write_packet(DEAD_NET, context.net, nh, list, text);
 }
 
 static bool handle_packet(
@@ -165,15 +167,15 @@ static bool handle_packet(
     if (nh.minor_type == 0) {
       // Feedback to sysop from the NC.  
       // This is sent to the #1 account as source verified email.
-      return handle_email(context, 1, nh, text);
+      return handle_email(context, 1, nh, list, text);
     } else {
-      return handle_net_info_file(context.net, nh, text);
+      return handle_net_info_file(context.net, nh, list, text);
     }
   break;
   case main_type_email:
     // This is regular email sent to a user number at this system.
     // Email has no minor type, so minor_type will always be zero.
-    return handle_email(context, nh.touser, nh, text);
+    return handle_email(context, nh.touser, nh, list, text);
   break;
   case main_type_new_post:
   {
@@ -181,7 +183,7 @@ static bool handle_packet(
   } break;
   case main_type_ssm:
   {
-    return handle_ssm(context, nh, text);
+    return handle_ssm(context, nh, list, text);
   } break;
   // The other email type.  The touser field is zero, and the name is found at
   // the beginning of the message text, followed by a NUL character.

--- a/network2/post.cpp
+++ b/network2/post.cpp
@@ -130,26 +130,26 @@ bool handle_post(Context& context, const net_header_rec& nh,
 
   string basename;
   if (!find_basename(context, subtype, basename)) {
-    LOG(INFO) << "    ! ERROR: Unable to find subtype of subtype: " << subtype;
-    return false;
+    LOG(INFO) << "    ! ERROR: Unable to find subtype of subtype: " << subtype << "; writing to dead.net.";
+    return write_packet(DEAD_NET, context.net, nh, list, text);
   }
 
   if (!context.api.Exist(basename)) {
     LOG(INFO) << "WARNING Message area: '" << basename << "' does not exist.";;
     LOG(INFO) << "WARNING Attempting to create it.";
     // Since the area does not exist, let's create it automatically
-    // like WWIV alwyas does.
+    // like WWIV always does.
     unique_ptr<MessageArea> creator(context.api.Create(basename));
     if (!creator) {
-      LOG(INFO) << "    ! ERROR: Failed to create message area: " << basename << ". Exiting.";
-      return false;
+      LOG(INFO) << "    ! ERROR: Failed to create message area: " << basename << "; writing to dead.net.";
+      return write_packet(DEAD_NET, context.net, nh, list, text);
     }
   }
 
   unique_ptr<MessageArea> area(context.api.Open(basename));
   if (!area) {
-    LOG(INFO) << "    ! ERROR Unable to open message area: '" << basename << "'.";
-    return false;
+    LOG(INFO) << "    ! ERROR Unable to open message area: " << basename << "; writing to dead.net.";
+    return write_packet(DEAD_NET, context.net, nh, list, text);
   }
 
   unique_ptr<Message> msg(area->CreateMessage());
@@ -184,8 +184,8 @@ bool handle_post(Context& context, const net_header_rec& nh,
   }
 
   if (!area->AddMessage(*msg)) {
-    LOG(INFO) << "     ! Failed to add message: " << title;
-    return false;
+    LOG(ERROR) << "     ! Failed to add message: " << title << "; writing to dead.net";
+    return write_packet(DEAD_NET, context.net, nh, list, text);
   }
   LOG(INFO) << "    + Posted  '" << title << "'";
   return true;


### PR DESCRIPTION
this covers a few of the cases where we can write to dead.net when things go wrong instead of letting the packet get offered to the ether.  Still have a few more to do, but wanted to start with what appeared to be more obvious.
