### PR TITLE
fixed forced init logic

### DIFF
--- a/init/init.cpp
+++ b/init/init.cpp
@@ -262,7 +262,7 @@ int WInitApp::main(int argc, char** argv) {
 
   if (need_to_initialize) {
     out->window()->Bkgd(' ');
-    if (!new_init(out->window(), bbsdir, forced_initialize)) {
+    if (!new_init(out->window(), bbsdir, need_to_initialize)) {
       return 2;
     }
   }


### PR DESCRIPTION
If we get inside the need_to_initialize, then the value being sent to new_init() should always be true, but forced_initialize is only true if the CLI arg --initialize is set, which doesn't make sense once we get here (ie, "yes, we need to init, but don't do it" is a logic fail).