### PR TITLE
issue992 connection_type fix

### DIFF
--- a/wwivd/wwivd.cpp
+++ b/wwivd/wwivd.cpp
@@ -398,7 +398,7 @@ int Main(CommandLine& cmdline) {
       closesocket(client_sock);
     }
 #else
-    auto f = [&]{
+    auto f = [&config,&c,&client_sock,connection_type]{
       HandleAccept(config, c, client_sock, connection_type);
     };
     std::thread client(f);

--- a/wwivd/wwivd.cpp
+++ b/wwivd/wwivd.cpp
@@ -398,6 +398,10 @@ int Main(CommandLine& cmdline) {
       closesocket(client_sock);
     }
 #else
+    // Changed the lambda to explicitly use the value for connection_type
+    // rather than by reference because linux is using ConnectionType::TELNET
+    // for ALL incoming connections when calling HandleAccept even though they
+    // are correct at initial connection time. issue992
     auto f = [&config,&c,&client_sock,connection_type]{
       HandleAccept(config, c, client_sock, connection_type);
     };


### PR DESCRIPTION
Apparently, linux didn't like the lambda function being used for the HandleAccept.  Tracked down that the connection_type was being recorded correctly on the initial connection, but once it got to std::thread cleint(f), the "by reference" it was using was not the expected one.  Changed the lambda to explicitly use the value for connection_type rather than by reference.

Incidentally, this also fixed SSH connections because ALL connections were using the ConnectionType::TELNET enumueration.