### PR TITLE
add wwiv::core namespace

### DIFF
--- a/core/os_unix.cpp
+++ b/core/os_unix.cpp
@@ -25,6 +25,7 @@
 
 using namespace std::chrono;
 using std::string;
+using namespace wwiv::core;
 using namespace wwiv::strings;
 
 namespace wwiv {


### PR DESCRIPTION
adding missing wwiv::core namespace reference in os_unix