### PR TITLE
make systemd happy on wwivd exit

### DIFF
--- a/wwivd/wwivd.cpp
+++ b/wwivd/wwivd.cpp
@@ -217,7 +217,7 @@ int Main(CommandLine& cmdline) {
     LOG(INFO) << "Error accepting client socket. " << errno;
     return 2;
   }
-  return EXIT_FAILURE;
+  return EXIT_SUCCESS;
 }
 
 } // namespace wwivd


### PR DESCRIPTION
during a normal systemctl stop wwivd, we were throwing a failure at systemd, which isn't correct.  A successful stop should not be an error.