### PR TITLE
Added missing commas into bad_filename

### DIFF
--- a/bbs/xfertmp.cpp
+++ b/bbs/xfertmp.cpp
@@ -63,10 +63,10 @@ bool bad_filename(const char *file_name) {
   static const vector<string> bad_words = {
       "COMMAND",
       "..",
-      "CMD"
-      "4DOS"
-      "4OS2"
-      "4NT"
+      "CMD",
+      "4DOS",
+      "4OS2",
+      "4NT",
       "PKZIP",
       "PKUNZIP",
       "ARJ",


### PR DESCRIPTION
The bad_filename function listed bad words, but some commas were missing from the list, thus some bad words were not prevented.