### PR TITLE
Lastcallers

### DIFF
--- a/bbs/lilo.cpp
+++ b/bbs/lilo.cpp
@@ -72,6 +72,7 @@ using std::chrono::duration;
 using std::chrono::duration_cast;
 using std::chrono::milliseconds;
 using std::chrono::seconds;
+using namespace wwiv::bbs::menus;
 using namespace wwiv::common;
 using namespace wwiv::core;
 using namespace wwiv::os;
@@ -529,35 +530,6 @@ static void UpdateLastOnFile() {
     lines = laston_file.ReadFileIntoVector();
   }
 
-  if (!lines.empty()) {
-    bool needs_header = true;
-    for (const auto& line : lines) {
-      if (line.empty()) {
-        continue;
-      }
-      if (needs_header) {
-        bout.nl(2);
-        bout.outstr("|#1Last few callers|#7: |#0");
-        bout.nl(2);
-        if (a()->HasConfigFlag(OP_FLAGS_SHOW_CITY_ST) &&
-            a()->config()->newuser_config().use_address_city_state != newuser_item_type_t::unused) {
-          bout.pl("|#2Number Name/Handle               Time  Date  City            ST Cty Speed    ##");
-        } else {
-          bout.pl("|#2Number Name/Handle               Language   Time  Date  Speed                ##");
-        }
-        const auto hz = okansi() ? '\xCD' : '=';
-        bout.print("|#7{}\r\n", std::string(79, hz));
-        needs_header = false;
-      }
-      bout.pl(line);
-      if (bin.checka()) {
-        break;
-      }
-    }
-    bout.nl(2);
-    bout.pausescr();
-  }
-
 
   auto status = a()->status_manager()->get_status();
   {
@@ -856,6 +828,7 @@ void logon() {
   UpdateUserStatsForLogin();
 
   PrintLogonFile();
+  LastCallers();
   UpdateLastOnFile();
 
   if (a()->config()->toggles().lastnet_at_logon) {

--- a/bbs/menus/menusupp.cpp
+++ b/bbs/menus/menusupp.cpp
@@ -237,6 +237,10 @@ void KillEMail() {
 }
 
 void LastCallers() {
+  if (a()->user()->clear_screen()) bout.cls();
+  bout.nl(2);
+  bout.print("|#1Last few callers to |#5{}|#7: |#0\r\n", a()->config()->system_name() );
+  bout.nl(2);
   if (a()->HasConfigFlag(OP_FLAGS_SHOW_CITY_ST) &&
       a()->config()->newuser_config().use_address_city_state != newuser_item_type_t::unused) {
     bout.outstr("|#2Number Name/Handle               Time  Date  City            ST Cty Modem    ##\r\n");
@@ -246,6 +250,9 @@ void LastCallers() {
   const char filler_char = okansi() ? '\xCD' : '=';
   bout.print("|#7{}\r\n", std::string(79, filler_char));
   bout.printfile(LASTON_TXT);
+  bout.print("|#7{}\r\n", std::string(79, filler_char));
+  bout.nl();
+  bout.pausescr();
 }
 
 void ReadEMail() {


### PR DESCRIPTION
Removes redundant code in lilo for displaying last callers. UpdateLastOnFile no longer displays file, only updates it.