### PR TITLE
Make fsed/view.cpp use default screen settings for max values

### DIFF
--- a/fsed/view.cpp
+++ b/fsed/view.cpp
@@ -38,8 +38,8 @@ namespace wwiv::fsed {
 
 FsedView::FsedView(const FullScreenView& fs, MessageEditorData& data, bool file)
     : fs_(fs), bout_(fs_.out()), bin_(fs_.in()), data_(data), file_(file) {
-  max_view_lines_ = std::max<int>(20, fs.message_height() - 1);
-  max_view_columns_ = std::max<int>(fs.screen_width(), 79);
+  max_view_lines_ = fs.message_height() - 1;
+  max_view_columns_ = fs.screen_width();
 }
 
 FullScreenView& FsedView::fs() { return fs_; }


### PR DESCRIPTION
Assume that the default screen settings are true and use width and height values for fsed/view instead of using a max or min value. Note that if the max values of 79 and 20 are not arbitrary, we can change this to use those again.

Fixes #1578