### PR TITLE
Removed dangling RE: with title for new posts

### DIFF
--- a/bbs/inmsg.cpp
+++ b/bbs/inmsg.cpp
@@ -366,14 +366,14 @@ static void UpdateMessageBufferInReplyToInfo(std::ostringstream& ss, bool is_ema
   if (!is_email) {
     // I don't think either RE: or BY lines should show up in email messages.
     // Also the message SDK only has support for adding them to subs, not emails too.
-    if (!title.empty() && title.front() != '"' && !fido_addr_added) {
+    if (!to_name.empty() && !iequals(to_name, "All")) {
+      if (!title.empty() && title.front() != '"' && !fido_addr_added) {
       // Don't add RE: line if we have a "^D0FidoAddr" line.
       ss << "RE: " << title << crlf;
-    }
-    if (!to_name.empty() && !iequals(to_name, "All")) {
+      }
       ss << "BY: " << to_name << crlf;
     }
-    ss << crlf;
+    // ss << crlf; // Do we really want this extra line?
   }
 }
 


### PR DESCRIPTION
* If posting to all (the normal post style in WWIV), RE: lines are not added to the message headers.
* Removed unneeded blank line at start of a new post.

Fixes #1589