### PR TITLE
Fix -1 Chatroom, and in-ability to exit if CH_PROMPT=1

### DIFF
--- a/bbs/chat.cpp
+++ b/bbs/chat.cpp
@@ -186,6 +186,9 @@ void chat_room() {
       bout.nl();
       bout.outstr("|#1Select a chat channel to enter:\r\n");
       loc = change_channels(-1);
+      if (loc == -1) {
+        return;
+      }
     }
   } else {
     if (a()->user()->restrict_iichat() || !check_ch(1)) {


### PR DESCRIPTION
Fixes Local chat bug.

If CH_PROMPT = 1 in chat.ini.  Entering "Q" at channel select will create a -1 non-functional chat location that can't be exited.

Fix returns to main if Q or -1 is entered. 