### PR TITLE
Fix -1 Chatroom, and in-ability to exit if CH_PROMPT=1

### DIFF
--- a/bbs/chat.cpp
+++ b/bbs/chat.cpp
@@ -186,6 +186,9 @@ void chat_room() {
       bout.nl();
       bout.outstr("|#1Select a chat channel to enter:\r\n");
       loc = change_channels(-1);
+      if (loc == -1) {
+        return;
+      }
     }
   } else {
     if (a()->user()->restrict_iichat() || !check_ch(1)) {


### PR DESCRIPTION
Goofed Branch on last round.

Bug: 
If CH_PROMPT = 1 in chat.ini,  a non-functional room number of -1 will be created.  This lead to an inability to quit chat.

Fix: 
Return to main if chat room is -1 (or Q)
