### PR TITLE
Update view.cpp to add / help message

### DIFF
--- a/fsed/view.cpp
+++ b/fsed/view.cpp
@@ -49,7 +49,7 @@ void FsedView::gotoxy(const FsedModel& ed) {
 }
 
 void FsedView::ClearCommandLine() { 
-    fs_.PutsCommandLine("|#9(|#2ESC|#9=Menu/Help) "); }
+    fs_.PutsCommandLine("|#9(|#2ESC|#9 or |#2/|#9=Menu/Help) "); }
 
 void FsedView::macro(Context& ctx, int cc) {
   if (!ctx.session_context().okmacro() || bin.charbufferpointer_) {


### PR DESCRIPTION
Added such that / and ESC both display at bottom as valid ways in the FSED to bring up the  menu.