### PR TITLE
Revert "Add config and check for user to enter full real name"

### DIFF
--- a/bbs/newuser.cpp
+++ b/bbs/newuser.cpp
@@ -63,7 +63,6 @@
 #include "sdk/usermanager.h"
 #include <chrono>
 #include <string>
-#include <sstream>
 
 using std::chrono::milliseconds;
 using wwiv::common::InputMode;
@@ -171,26 +170,13 @@ void input_name() {
   } while (!ok && !a()->sess().hangup());
 }
 
-// Function to check if both first and last names are entered
-bool containsFirstAndLastName(const std::string& name) {
-    std::istringstream stream(name);
-    std::string part;
-    int count = 0;
-    
-    while (stream >> part) {
-        ++count;
-    }
-    
-    return count >= 2;
-}
-
 void input_realname() {
   if (a()->config()->sysconfig_flags() & sysconfig_allow_alias) {
     do {
       bout.nl();
       bout.outstr("|#3Enter your FULL real name.\r\n");
       std::string temp_local_name = bin.input_proper(a()->user()->real_name(), 30);
-      if (temp_local_name.empty() || ((nc.first_last_name_required == newuser_item_type_t::required) && !containsFirstAndLastName(temp_local_name) )) {
+      if (temp_local_name.empty()) {
         bout.nl();
         bout.outstr("|#6Sorry, you must enter your FULL real name.\r\n");
       } else {

--- a/sdk/config.h
+++ b/sdk/config.h
@@ -49,7 +49,6 @@ struct newuser_config_t {
   newuser_item_type_t use_birthday{newuser_item_type_t::required};
   newuser_item_type_t use_computer_type{newuser_item_type_t::required};
   newuser_item_type_t use_email_address{newuser_item_type_t::required};
-  newuser_item_type_t first_last_name_required{newuser_item_type_t::required};
 };
 
 struct system_toggles_t {

--- a/wwivconfig/new_user.cpp
+++ b/wwivconfig/new_user.cpp
@@ -76,14 +76,9 @@ void newuser_settings(wwiv::sdk::Config& config, wwiv::sdk::newuser_config_t& nc
   items.add(new Label("Real Name:"),
             new ToggleEditItem<wwiv::sdk::newuser_item_type_t>(newuser_item_type_list, &nc.use_real_name),
     "Ask Callers for a real name. This may be needed for some networks", 1, y);
-  items.add(new Label("First & Last Name Required:"),
-            new ToggleEditItem<wwiv::sdk::newuser_item_type_t>(newuser_item_type_list, &nc.first_last_name_required),
-    "Require both a first and last name if real name is required", 3, y);
-  ++y;
   items.add(new Label("Email Address:"),
             new ToggleEditItem<wwiv::sdk::newuser_item_type_t>(newuser_item_type_list, &nc.use_email_address),
-    "Ask callers for an email address", 1, y);
-  ++y;
+    "Ask callers for an email address", 3, y);
   ++y;
   items.add(new Label("Voice Phone:"),
             new ToggleEditItem<wwiv::sdk::newuser_item_type_t>(newuser_item_type_list, &nc.use_voice_phone),


### PR DESCRIPTION
Reverts wwivbbs/wwiv#1660

This merge results in the following error on building:

```
[118/348] Building CXX object bbs/CMakeFiles/bbs_lib.dir/newuser.cpp.o
FAILED: bbs/CMakeFiles/bbs_lib.dir/newuser.cpp.o 
/usr/bin/g++-12 -DFMT_HEADER_ONLY=1 -DWWIV_HAS_SSH_CRYPTLIB -D_DEBUG -I/home/wwiv/github/wwiv -I/home/wwiv/github/wwiv/bbs/../deps/cl345 -isystem /home/wwiv/github/wwiv-build/vcpkg_installed/x64-linux/include -g -std=gnu++17 -MD -MT bbs/CMakeFiles/bbs_lib.dir/newuser.cpp.o -MF bbs/CMakeFiles/bbs_lib.dir/newuser.cpp.o.d -o bbs/CMakeFiles/bbs_lib.dir/newuser.cpp.o -c /home/wwiv/github/wwiv/bbs/newuser.cpp
/home/wwiv/github/wwiv/bbs/newuser.cpp: In function ‘void input_realname()’:
/home/wwiv/github/wwiv/bbs/newuser.cpp:193:40: error: ‘nc’ was not declared in this scope
  193 |       if (temp_local_name.empty() || ((nc.first_last_name_required == newuser_item_type_t::required) && !containsFirstAndLastName(temp_local_name) )) {
      |                                        ^~
[119/348] Building CXX object bbs/CMakeFiles/bbs_lib.dir/netsup.cpp.o
ninja: build stopped: subcommand failed.
```
I tested reversing the patch and compilation proceeds without any error. 